### PR TITLE
Start sketching CBPV implementation in Scala

### DIFF
--- a/Development.md
+++ b/Development.md
@@ -1,0 +1,10 @@
+# Naming conventions
+
+(To extend).
+
+## Currently-used (and preferred) identifiers
+
+### Variable names
+
+Terms: t, term
+Type: (t), typ, tau

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Building
 ========
 
 This code can be compiled using [SBT](http://www.scala-sbt.org/). Development
-should follow the style guide available at http://docs.scala-lang.org/style/.
+should follow the style guide available at http://docs.scala-lang.org/style/ and
+the project-specific guidelines at <Development.md>.
 
 [![Build Status](https://travis-ci.org/inc-lc/ilc-scala.svg?branch=master)](https://travis-ci.org/inc-lc/ilc-scala)
 

--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ with
 ```
   val value = false
 ```
-in `scala-prototype/src/test/scala/ilc/examples/bench/FastBenchmarksFlag.scala`
+in `src/test/scala/ilc/examples/bench/FastBenchmarksFlag.scala`
 (this will affect the actual parameters set in
-`scala-prototype/src/test/scala/ilc/examples/bench/HistogramBenchmark.scala` and
-`scala-prototype/src/test/scala/ilc/examples/ExampleToBenchmark.scala`).
+`src/test/scala/ilc/examples/bench/HistogramBenchmark.scala` and
+`src/test/scala/ilc/examples/ExampleToBenchmark.scala`).
 
 
 Cross reference

--- a/icfp2014/src/main/scala/ilc/language/gcc/LambdaManApi.scala
+++ b/icfp2014/src/main/scala/ilc/language/gcc/LambdaManApi.scala
@@ -260,7 +260,7 @@ trait Collection extends SyntaxSugar { outer =>
         UnitType =>: bool,
         UnitType =>: ListType((KeyType, ValueType)))
 
-  def HashMapClass(KeyType: Type, ValueType: Type)(name: Symbol): (Symbol, UT) =
+  def HashMapClass(KeyType: Type, ValueType: Type)(name: Symbol): (Name, UT) =
     class_(name)('store % BinTreeType((KeyType, ValueType)), 'compare % (KeyType =>: KeyType =>: int)) (
 
       fun('get)('key % KeyType) {

--- a/icfp2014/src/main/scala/ilc/language/gcc/Syntax.scala
+++ b/icfp2014/src/main/scala/ilc/language/gcc/Syntax.scala
@@ -89,11 +89,9 @@ trait SyntaxSugar
 {
   outer =>
   implicit def intToUTerm(n: Int): UntypedTerm = asUntyped(LiteralInt(n))
-  def letrec(pairs: (Symbol, UntypedTerm)*)
+  def letrec(pairs: (Name, UntypedTerm)*)
         (bodyName: String, body: UntypedTerm): UntypedTerm = {
-    ULetRec(pairs.toList map {
-      case (sym, t) => (sym.name, t)
-    }, bodyName, body)
+    ULetRec(pairs.toList, bodyName, body)
   }
 
   type UT = UntypedTerm
@@ -131,7 +129,7 @@ trait SyntaxSugar
   def switch(value: UntypedTerm)(branches: (UntypedTerm, UntypedTerm)*) = WithDefault(value, branches)
   case class WithDefault(value: UntypedTerm, branches: Seq[(UntypedTerm, UntypedTerm)]) {
     def withDefault(default: UntypedTerm): UntypedTerm = {
-      val condName = Symbol(freshener.fresh("cond", int).getName.toString)
+      val condName = freshener.fresh("cond", int).getName.toString
       let(condName, value)(branches.foldRight(default) {
         case ((comp, body), els) => if_(condName === comp)(body) else_(els)
       })
@@ -151,7 +149,7 @@ trait SyntaxSugar
   def noop = Noop
 
   // Symbol + TypeAnnotation
-  type NameOrTyped = Either[Symbol, TypeAnnotation]
+  type NameOrTyped = Either[Name, TypeAnnotation]
   implicit def symbolIsLeft(s: Symbol): NameOrTyped = Left(s)
   implicit def annotationIsRight(anno: TypeAnnotation): NameOrTyped = Right(anno)
 
@@ -165,18 +163,17 @@ trait SyntaxSugar
   // creates a pair to be used immediately in letrec like
   //   letrec(fun('go)('n) { 'to('n + 1) })
   def fun(name: Symbol)(firstArg: NameOrTyped, args: NameOrTyped*)(body: UntypedTerm) =
-    (name -> lam(firstArg, args: _*)(body))
+    name := lam(firstArg, args: _*)(body)
 
 
   //For use within letS.
   //Example:
   //letS('a := 1, 'b := 2){3}
-  implicit class SymBindingOps(s: Symbol) {
-    def :=(t: UntypedTerm) = s -> t
-
+  implicit class NameAssignOps(s: Name) {
     // For assignment
     def <~(term: UT) = asUntyped(Assign)(s, term)
   }
+  implicit def symToNameAssignOps(s: Symbol) = (s: Name): NameAssignOps
 
   implicit def consSyntax[A <% UT, B <% UT](scalaPair: (A, B)): UntypedTerm =
     pair(scalaPair._1, scalaPair._2)
@@ -195,7 +192,7 @@ trait SyntaxSugar
         letS(
          (firstName +: names).zipWithIndex.map {
            case (Left(name), i) => name := tuple at(i, size)
-           case (Right(TypeAnnotation(name, tpe)), i) => Symbol(name) := tuple at(i, size) ofType (tpe)
+           case (Right(TypeAnnotation(name, tpe)), i) => Symbol(name.toString) := tuple at(i, size) ofType (tpe)
          }: _*)(body)
       }
     }
@@ -203,11 +200,11 @@ trait SyntaxSugar
 
   type ClassTag = Int
   private val classTags = mutable.Map.empty[Symbol, ClassTag]
-  private val classMethods = mutable.Map.empty[ClassTag, Seq[Symbol]]
+  private val classMethods = mutable.Map.empty[ClassTag, Seq[Name]]
 
-  def ClassType(memberTypes: Type*) = tupleType((int +: memberTypes):_*)
+  def ClassType(memberTypes: Type*) = tupleType((int +: memberTypes): _*)
 
-  def class_(name: Symbol)(fields: NameOrTyped*)(members: (Symbol, UT)*) = {
+  def class_(name: Symbol)(fields: NameOrTyped*)(members: (Name, UT)*) = {
 
     val memberNames = members.map { _._1 }
     val memberRefs = memberNames.map(m => asUntyped(m))
@@ -217,8 +214,8 @@ trait SyntaxSugar
     classMethods.update(classTag, memberNames)
 
     // we return the constructor
-    Symbol("new_" + name.name) -> lam(fields.head, fields.tail:_*){
-      letrec( members:_* )(name.name, tuple(classTag , memberRefs:_*))
+    Symbol("new_" + name.name) := lam(fields.head, fields.tail: _*){
+      letrec(members: _*)(name.name, tuple(classTag , memberRefs: _*))
     }
   }
 

--- a/icfp2014/src/main/scala/ilc/language/gcc/Syntax.scala
+++ b/icfp2014/src/main/scala/ilc/language/gcc/Syntax.scala
@@ -220,7 +220,7 @@ trait SyntaxSugar
   }
 
   implicit class MethodCallOps[T <% UT](term: T) {
-    def call(className: Symbol, methodName: Symbol)(args: UT*) = {
+    def call(className: Symbol, methodName: Name)(args: UT*) = {
       val classTag = classTags(className)
       val methodList = classMethods(classTag)
       val idx = methodList.indexOf(methodName)

--- a/src/main/scala/ilc/TypeChecking.scala
+++ b/src/main/scala/ilc/TypeChecking.scala
@@ -5,5 +5,5 @@ object TypeChecking extends util.BooleanFlag {
     * Define this to false to disable some internal typechecking checks, which might be useful
     * for chaotic prototyping.
     */
-  val value = false
+  val value = true
 }

--- a/src/main/scala/ilc/feature/base/Names.scala
+++ b/src/main/scala/ilc/feature/base/Names.scala
@@ -20,6 +20,7 @@ trait Names {
 
   implicit def stringAsLiteralName(string: String): NonIndexedName =
     LiteralName(string)
+  implicit def symToName(s: Symbol): Name = s.name
 
   // NAME CLASSES IN ALPHABETIC ORDER
 

--- a/src/main/scala/ilc/feature/base/Syntax.scala
+++ b/src/main/scala/ilc/feature/base/Syntax.scala
@@ -264,6 +264,10 @@ Please do not declare getType as an abstract `val`.
   implicit def closeTermBuilder(builder: TermBuilder): Term =
     builder(TypingContext.empty).toTerm
 
+  //Chain implicit conversions
+  implicit def closeNameTermBuilder(name: Name): Term =
+    (name: TermBuilder): Term
+
   /** Convenient operator to give polymorphic terms arguments */
   implicit class BaseTermBuilderOps[T <% TermBuilder](t: T) {
     // activates implicit conversion

--- a/src/main/scala/ilc/feature/base/Syntax.scala
+++ b/src/main/scala/ilc/feature/base/Syntax.scala
@@ -88,11 +88,11 @@ Please do not declare getType as an abstract `val`.
     *         of `context`
     *
     * {{{
-    * freshName(englishMonachs, "Attila")    = "Attila"
-    * freshName(englishMonachs, "Elisabeth") = "Elizabeth_3"
+    * ctxToFreshName(englishMonachs, "Attila")    = "Attila"
+    * ctxToFreshName(englishMonachs, "Elisabeth") = "Elizabeth_3"
     * }}}
     */
-  def freshName(context: TypingContext, _default: Name): Name = {
+  def ctxToFreshName(context: TypingContext, _default: Name): Name = {
     val (default, startIdx) = decomposeName(_default)
     var newName: Name = default
     var index = startIdx

--- a/src/main/scala/ilc/feature/base/Syntax.scala
+++ b/src/main/scala/ilc/feature/base/Syntax.scala
@@ -310,9 +310,8 @@ trait FreshGen {
     index = 0
   }
 
-  def fresh(varName: Name, varType: Type): Var = {
+  def freshName(varName: Name): Name = {
     index += 1
-    //Var(IndexedName("z", index), varType)
     val compress = false
     val baseName =
       if (compress)
@@ -320,7 +319,12 @@ trait FreshGen {
       else
         //Keep names, for extra readability.
         decomposeName(varName)._1
-    Var(IndexedName(baseName, index), varType)
+    //IndexedName("z", index)
+    IndexedName(baseName, index)
+  }
+
+  def fresh(varName: Name, varType: Type): Var = {
+    Var(freshName(varName), varType)
   }
 
   def fresh(v: Var): Var = fresh(v.getName, v.getType)

--- a/src/main/scala/ilc/feature/cbpv/Syntax.scala
+++ b/src/main/scala/ilc/feature/cbpv/Syntax.scala
@@ -1,0 +1,45 @@
+package ilc
+package feature
+package cbpv
+
+trait Syntax extends functions.Syntax with Types with TypeUtils {
+  case class Produce(v: Term) extends Term {
+    val getType: Type = FProducerType(v.getType)
+  }
+
+  //Aaargh.... names!
+  //case class Bind(v: Term, )
+
+  case class Thunk(v: Term) extends Term {
+    val getType: Type = UThunkType(v.getType)
+  }
+
+  case class Force(v: Term) extends Term {
+    val getType: Type =
+      stripFType(v.getType)
+  }
+}
+
+trait CBPVSyntax extends CBPVTypes with base.Names {
+  trait CompTerm
+  trait ValTerm
+  case class VarVT(n: Name, t: ValType) extends ValTerm
+
+  case class ThunkVT(c: CompTerm) extends ValTerm
+  case class ForceCT(v: ValTerm) extends CompTerm
+}
+
+trait SyntaxConversions extends Syntax with CBPVSyntax with TypeConversions {
+  def cbnToCBPV(t: Term): CompTerm = t match {
+    case Var(n, cbnTyp) =>
+      val cbpvTyp = cbnTypeToCBPV(cbnTyp)
+      ForceCT(VarVT(n, stripFComp(cbpvTyp)))
+    case Abs(v, body) =>
+      ???
+  }
+
+  def cbvToCBPV(t: Term): ValTerm = t match {
+    case Abs(v, body) =>
+      ThunkVT(???)
+  }
+}

--- a/src/main/scala/ilc/feature/cbpv/Syntax.scala
+++ b/src/main/scala/ilc/feature/cbpv/Syntax.scala
@@ -22,26 +22,92 @@ trait Syntax extends functions.Syntax with Types with TypeUtils {
 }
 */
 
+//Let's use restricted CBPV.
+//XXX the naming scheme is broken: VT and CT are also used as suffixes for value
+//types.
 trait CBPVSyntax extends CBPVTypes with base.Names {
   trait CompTerm
   trait ValTerm
-  case class VarVT(n: Name, t: ValType) extends ValTerm
 
+  /////////////////////
+  //   Value terms   //
+  /////////////////////
+
+  //vVar : ∀ {τ} (x : ValVar Γ τ) → Val Γ τ
+  case class VarVT(n: Name, t: ValType) extends ValTerm
+  //vThunk : ∀ {τ} → Comp Γ τ → Val Γ (U τ)
   case class ThunkVT(c: CompTerm) extends ValTerm
+
+  // And value constants:
+  //vConst : ∀ {Σ τ} →
+  //  (c : ValConst Σ τ) →
+  //  (args : Vals Γ Σ) →
+  //  Val Γ τ
+
+  ///////////////////////
+  // Computation terms //
+  ///////////////////////
+
+  //cAbs : ∀ {σ τ} →
+  //  (t : Comp (σ •• Γ) τ) →
+  //  Comp Γ (σ ⇛ τ)
+  case class AbsCT(n: VarVT, body: CompTerm) extends CompTerm
+
+  //cApp : ∀ {σ τ} →
+  //  (s : Comp Γ (σ ⇛ τ)) →
+  //  (t : Val Γ σ) →
+  //  Comp Γ τ
+  case class AppCT(f: CompTerm, arg: ValTerm) extends CompTerm
+
+  //_into_ : ∀ {σ τ} →
+  //  (e₁ : Comp Γ (F σ)) →
+  //  (e₂ : Comp (σ •• Γ) (F τ)) →
+  //  Comp Γ (F τ)
+  case class BindCT(e1: CompTerm, n: VarVT, e2: CompTerm) extends CompTerm
+
+  //cForce : ∀ {τ} → Val Γ (U τ) → Comp Γ τ
   case class ForceCT(v: ValTerm) extends CompTerm
+
+  //cReturn : ∀ {τ} (v : Val Γ τ) → Comp Γ (F τ)
+  case class ReturnCT(v: ValTerm) extends CompTerm
+
+  // And computation constants:
+  //cConst : ∀ {Σ τ} →
+  //  (c : CompConst Σ τ) →
+  //  (args : Vals Γ Σ) →
+  //  Comp Γ τ
 }
 
-trait SyntaxConversions extends Syntax with CBPVSyntax with TypeConversions {
+trait SyntaxConversions extends functions.Syntax with CBPVSyntax with TypeConversions {
+  outer =>
+  private val freshGen = new base.FreshGen { lazy val syntax: outer.type = outer }
+  import freshGen.freshName
+
   def cbnToCBPV(t: Term): CompTerm = t match {
     case Var(n, cbnTyp) =>
       val cbpvTyp = cbnTypeToCBPV(cbnTyp)
       ForceCT(VarVT(n, stripFComp(cbpvTyp)))
     case Abs(v, body) =>
-      ???
+      AbsCT(VarVT(v.getName, UThunkVT(cbnTypeToCBPV(v.getType))), cbnToCBPV(body))
+    case App(f, arg) =>
+      AppCT(cbnToCBPV(f), ThunkVT(cbnToCBPV(arg)))
   }
 
-  def cbvToCBPV(t: Term): ValTerm = t match {
+  def cbvValueToCBPV(t: Term): ValTerm = t match {
     case Abs(v, body) =>
-      ThunkVT(???)
+      ThunkVT(AbsCT(VarVT(v.getName, cbvTypeToCBPV(v.getType)), cbvToCBPV(body)))
+    case v: Var =>
+      VarVT(v.getName, cbvTypeToCBPV(v.getType))
+  }
+
+  def cbvToCBPV(t: Term): CompTerm = t match {
+    case App(f, arg) =>
+      val argV = VarVT(freshName("a"), cbvTypeToCBPV(arg.getType))
+      val fV = VarVT(freshName("f"), cbvTypeToCBPV(f.getType))
+      BindCT(cbvToCBPV(arg), argV,
+        BindCT(cbvToCBPV(f), fV,
+          AppCT(ForceCT(fV), argV)))
+    case value =>
+      ReturnCT(cbvValueToCBPV(value))
   }
 }

--- a/src/main/scala/ilc/feature/cbpv/Syntax.scala
+++ b/src/main/scala/ilc/feature/cbpv/Syntax.scala
@@ -2,13 +2,14 @@ package ilc
 package feature
 package cbpv
 
+/*
 trait Syntax extends functions.Syntax with Types with TypeUtils {
-  case class Produce(v: Term) extends Term {
+  case class Return(v: Term) extends Term {
     val getType: Type = FProducerType(v.getType)
   }
 
   //Aaargh.... names!
-  //case class Bind(v: Term, )
+  //case class Bind(e1: Term, v: Term, e2: Term)
 
   case class Thunk(v: Term) extends Term {
     val getType: Type = UThunkType(v.getType)
@@ -19,6 +20,7 @@ trait Syntax extends functions.Syntax with Types with TypeUtils {
       stripFType(v.getType)
   }
 }
+*/
 
 trait CBPVSyntax extends CBPVTypes with base.Names {
   trait CompTerm

--- a/src/main/scala/ilc/feature/cbpv/Types.scala
+++ b/src/main/scala/ilc/feature/cbpv/Types.scala
@@ -1,0 +1,105 @@
+package ilc
+package feature
+package cbpv
+
+trait Types extends functions.Types {
+  //U
+  case class UThunkType(t: Type) extends Type {
+    override def toString = s"U($t)"
+    override def traverse(f: Type => Type): Type =
+      copy(f(t))
+  }
+  //F
+  case class FProducerType(t: Type) extends Type {
+    override def toString = s"F($t)"
+    override def traverse(f: Type => Type): Type =
+      copy(f(t))
+  }
+}
+
+trait TypeUtils {
+  this: Types =>
+
+  def stripFType(ct: Type): Type = ct match {
+    case FProducerType(vt) => vt
+    case _ => ???
+  }
+}
+
+//For now, just the very core type language.
+trait CBPVTypes {
+  sealed trait ValType
+  case class UThunkVT(t: CompType) extends ValType
+  case object UnitVT extends ValType
+  case class ProdVT(a: ValType, b: ValType) extends ValType
+
+  //The original language has indexed sums, not binary ones.
+  case class SumVT(a: ValType, b: ValType) extends ValType
+
+  sealed trait CompType
+  case class FProducerCT(t: ValType) extends CompType
+  case class FunCT(s: ValType, t: CompType) extends CompType
+
+  //The original language has indexed products, not binary ones.
+  case class ProdCT(a: CompType, b: CompType) extends CompType
+}
+
+trait TypeConversions extends CBPVTypes with Types with unit.Types with sums.Types with products.Types with booleans.Types {
+  def cbnTypeToCBPV(t: Type): CompType = t match {
+    case s =>: t =>
+      FunCT(UThunkVT(
+        cbnTypeToCBPV(s)),
+        cbnTypeToCBPV(t))
+    case ProductType(a, b) =>
+      ProdCT(
+        cbnTypeToCBPV(a),
+        cbnTypeToCBPV(b))
+    case SumType(a, b) =>
+      FProducerCT(SumVT(
+        UThunkVT(cbnTypeToCBPV(a)),
+        UThunkVT(cbnTypeToCBPV(b))))
+    case UnitType =>
+      FProducerCT(UnitVT)
+    case BooleanType =>
+      FProducerCT(SumVT(UnitVT, UnitVT))
+  }
+
+  def cbvTypeToCBPV(t: Type): ValType = t match {
+    case s =>: t =>
+      UThunkVT(FunCT(cbvTypeToCBPV(s), FProducerCT(cbvTypeToCBPV(t))))
+    case ProductType(a, b) =>
+      ProdVT(cbvTypeToCBPV(a), cbvTypeToCBPV(b))
+    case SumType(a, b) =>
+      SumVT(cbvTypeToCBPV(a), cbvTypeToCBPV(b))
+    case UnitType =>
+      UnitVT
+    case BooleanType =>
+      SumVT(UnitVT, UnitVT)
+  }
+
+  def compTypeToType(t: CompType): Type = t match {
+    case FProducerCT(t) => FProducerType(valTypeToType(t))
+    case FunCT(s, t) =>
+      valTypeToType(s) =>: compTypeToType(t)
+    //XXX We seem to erase the difference between the two different product types.
+    case ProdCT(a, b) =>
+      ProductType(compTypeToType(a), compTypeToType(b))
+  }
+
+  def valTypeToType(t: ValType): Type = t match {
+    case UThunkVT(t) => UThunkType(compTypeToType(t))
+    case UnitVT => UnitType
+    case SumVT(a, b) => SumType(valTypeToType(a), valTypeToType(b))
+    case ProdVT(a, b) => ProductType(valTypeToType(a), valTypeToType(b))
+  }
+
+  def stripUVal(vt: ValType): CompType = vt match {
+    case UThunkVT(ct) => ct
+    case _ => ???
+  }
+
+  def stripFComp(ct: CompType): ValType = ct match {
+    case FProducerCT(vt) => vt
+    case _ => ???
+  }
+}

--- a/src/main/scala/ilc/feature/cbpv/Types.scala
+++ b/src/main/scala/ilc/feature/cbpv/Types.scala
@@ -29,7 +29,7 @@ trait TypeUtils {
 }
 
 //For now, just the very core type language.
-trait CBPVTypes {
+trait CBPVTypes extends base.Types {
   sealed trait ValType
   case class UThunkVT(t: CompType) extends ValType
   case object UnitVT extends ValType
@@ -37,6 +37,7 @@ trait CBPVTypes {
 
   //The original language has indexed sums, not binary ones.
   case class SumVT(a: ValType, b: ValType) extends ValType
+  case class BaseVT(t: Type) extends ValType
 
   sealed trait CompType
   case class FProducerCT(t: ValType) extends CompType
@@ -77,6 +78,11 @@ trait TypeConversions extends CBPVTypes with Types with unit.Types with sums.Typ
       UnitVT
     case BooleanType =>
       SumVT(UnitVT, UnitVT)
+
+    //XXX This allows sticking in, among others, type variables.
+    //Since we don't require them to be value types in the source language,
+    //this might lead to problems.
+    case _ => BaseVT(t)
   }
 
   /*

--- a/src/main/scala/ilc/feature/cbpv/Types.scala
+++ b/src/main/scala/ilc/feature/cbpv/Types.scala
@@ -113,3 +113,34 @@ trait TypeConversions extends CBPVTypes with Types with unit.Types with sums.Typ
     case _ => ???
   }
 }
+
+trait CBPVToCPS extends TypeConversions with let.CPSTypes {
+  def cbvTypeToCPS(t: Type) = valTypeToCPS(cbvTypeToCBPV(t))
+
+  def valTypeToCPS(vt: ValType): Type = vt match {
+    case UThunkVT(ct) =>
+      compTypeToCPS(ct) =>: AnswerT
+    //These are value types, so they aren't serious
+    case UnitVT =>
+      UnitType
+    case SumVT(a, b) => SumType(valTypeToCPS(a), valTypeToCPS(b))
+    case ProdVT(a, b) => ProductType(valTypeToCPS(a), valTypeToCPS(b))
+    case BaseVT(t) => t
+  }
+
+  def compTypeToCPS(ct: CompType): Type = ct match {
+    case FProducerCT(vt) =>
+      valTypeToCPS(vt) =>: AnswerT
+    case FunCT(srcVt, dstCt) =>
+      // Tempting, but wrong:
+      //valTypeToCPS(srcVt) =>: compTypeToCPS(dstCt)
+
+      // According to the literature, we need the product of the types, which
+      // happens to be the adjoint (in fact, unsurprisingly, that's how this arises).
+      ProductType(valTypeToCPS(srcVt), compTypeToCPS(dstCt))
+    case ProdCT(a, b) =>
+      ???
+      //Heck, ProdCT is a pair of continuations.
+      //ProductType(compTypeToType(a), compTypeToType(b))
+  }
+}

--- a/src/main/scala/ilc/feature/cbpv/Types.scala
+++ b/src/main/scala/ilc/feature/cbpv/Types.scala
@@ -138,6 +138,18 @@ trait CBPVToCPS extends TypeConversions with let.CPSTypes {
       // According to the literature, we need the product of the types, which
       // happens to be the adjoint (in fact, unsurprisingly, that's how this arises).
       ProductType(valTypeToCPS(srcVt), compTypeToCPS(dstCt))
+      // In fact, we can even flip the operands, to pass the continuation first
+      // (and confusingly flip all other operands, but do we care?), as follows:
+      //ProductType(compTypeToCPS(dstCt), valTypeToCPS(srcVt))
+      //
+      //However, what's the matching change for the code transformation?
+      //Finally, taking continuations first (as in Fischer's transform) or last
+      //(as in Plotkin's transform) makes an amazing amount of difference
+      //theoretically. (See for instance Sabry and Wadler's "A Reflection on
+      //Call-by-Value"; see also footnote 12 of Hatcliff and Danvy's "A Generic
+      //Account of Continuation-Passing Style"). Apparently, taking
+      //continuations first enables doing more administrative reductions (for
+      //some purposes, too many).
     case ProdCT(a, b) =>
       ???
       //Heck, ProdCT is a pair of continuations.

--- a/src/main/scala/ilc/feature/cbpv/Types.scala
+++ b/src/main/scala/ilc/feature/cbpv/Types.scala
@@ -3,6 +3,7 @@ package feature
 package cbpv
 
 trait Types extends functions.Types {
+  /*
   //U
   case class UThunkType(t: Type) extends Type {
     override def toString = s"U($t)"
@@ -15,15 +16,16 @@ trait Types extends functions.Types {
     override def traverse(f: Type => Type): Type =
       copy(f(t))
   }
+  */
 }
 
 trait TypeUtils {
   this: Types =>
 
-  def stripFType(ct: Type): Type = ct match {
+  /*def stripFType(ct: Type): Type = ct match {
     case FProducerType(vt) => vt
     case _ => ???
-  }
+  }*/
 }
 
 //For now, just the very core type language.
@@ -77,6 +79,7 @@ trait TypeConversions extends CBPVTypes with Types with unit.Types with sums.Typ
       SumVT(UnitVT, UnitVT)
   }
 
+  /*
   def compTypeToType(t: CompType): Type = t match {
     case FProducerCT(t) => FProducerType(valTypeToType(t))
     case FunCT(s, t) =>
@@ -92,6 +95,7 @@ trait TypeConversions extends CBPVTypes with Types with unit.Types with sums.Typ
     case SumVT(a, b) => SumType(valTypeToType(a), valTypeToType(b))
     case ProdVT(a, b) => ProductType(valTypeToType(a), valTypeToType(b))
   }
+  */
 
   def stripUVal(vt: ValType): CompType = vt match {
     case UThunkVT(ct) => ct

--- a/src/main/scala/ilc/feature/functions/Syntax.scala
+++ b/src/main/scala/ilc/feature/functions/Syntax.scala
@@ -17,11 +17,11 @@ trait Syntax extends base.Syntax {
             expectedDomain,
             s"$operand : $actualDomain")
 
-      case _ =>
+      case (operatorType, actualDomain) =>
         typeErrorNotTheSame(
-          "operator position",
-          "function",
-          operator.getType)
+          s"operator position for operand $operand : $actualDomain",
+          s"function (with domain $actualDomain)",
+          s"$operator : $operatorType")
     }
   }
 

--- a/src/main/scala/ilc/feature/functions/Syntax.scala
+++ b/src/main/scala/ilc/feature/functions/Syntax.scala
@@ -86,7 +86,7 @@ trait Syntax extends base.Syntax {
   def mkLambda(nameSuggestion: Name, argumentType: Option[Type])
     (body: Name => TermBuilder): TermBuilder =
     context => {
-      val name = freshName(context, nameSuggestion)
+      val name = ctxToFreshName(context, nameSuggestion)
       argumentType match {
         case Some(knownType) =>
           new SpecializedAbs(name, context, body, knownType)

--- a/src/main/scala/ilc/feature/inference/Inference.scala
+++ b/src/main/scala/ilc/feature/inference/Inference.scala
@@ -26,6 +26,7 @@ extends base.Syntax
   case class TypeVariable(name: Int, uterm: Option[UntypedTerm] = None) extends Type {
     // We don't want to hash uterm for every lookup.
     override def hashCode() = name
+    override def toString = s"T$name"
   }
 
   val typeVariableCounter: AtomicInteger = new AtomicInteger()

--- a/src/main/scala/ilc/feature/inference/Inference.scala
+++ b/src/main/scala/ilc/feature/inference/Inference.scala
@@ -33,10 +33,10 @@ extends base.Syntax
   def freshTypeVariable(uterm: UntypedTerm): TypeVariable = _freshTypeVariable(Some(uterm))
   def freshTypeVariable: TypeVariable = _freshTypeVariable(None)
 
-  case class Constraint(_1: Type, _2: Type, ctx: String = "", parent: Option[Constraint] = None) {
+  case class Constraint(actual: Type, expected: Type, ctx: String = "", parent: Option[Constraint] = None) {
     def pretty(showTerm: Boolean = true): String =
-      s"""|Actual: ${_1}
-          |Expected: ${_2}
+      s"""|Actual: ${actual}
+          |Expected: ${expected}
           |${if (showTerm) s"From context: $ctx" else ""}
           |From constraint stack:
           |${parent.fold("")(_.pretty(false)) }
@@ -137,8 +137,8 @@ extends base.Syntax
     }
 
   def substituteInConstraint(substitutions: Map[TypeVariable, Type])(constraint: Constraint): Constraint =
-    Constraint(substituteInType(substitutions)(constraint._1),
-     substituteInType(substitutions)(constraint._2), constraint.ctx)
+    Constraint(substituteInType(substitutions)(constraint.actual),
+     substituteInType(substitutions)(constraint.expected), constraint.ctx)
 
   def substitute(substitutions: Map[TypeVariable, Type], term: TypedTerm): TypedTerm = term match {
     case TVar(name, typ) => TVar(name, substituteInType(substitutions)(typ))

--- a/src/main/scala/ilc/feature/inference/Inference.scala
+++ b/src/main/scala/ilc/feature/inference/Inference.scala
@@ -29,7 +29,9 @@ extends base.Syntax
   }
 
   val typeVariableCounter: AtomicInteger = new AtomicInteger()
-  def freshTypeVariable(uterm: UntypedTerm): TypeVariable = TypeVariable(typeVariableCounter.incrementAndGet(), Some(uterm))
+  def _freshTypeVariable(uterm: Option[UntypedTerm]): TypeVariable = TypeVariable(typeVariableCounter.incrementAndGet(), uterm)
+  def freshTypeVariable(uterm: UntypedTerm): TypeVariable = _freshTypeVariable(Some(uterm))
+  def freshTypeVariable: TypeVariable = _freshTypeVariable(None)
 
   case class Constraint(_1: Type, _2: Type, ctx: String = "", parent: Option[Constraint] = None) {
     def pretty(showTerm: Boolean = true): String =

--- a/src/main/scala/ilc/feature/inference/Inference.scala
+++ b/src/main/scala/ilc/feature/inference/Inference.scala
@@ -45,26 +45,26 @@ extends base.Syntax
 
   def emptyConstraintSet = Set[Constraint]()
 
-  type InferenceContext = List[(String, Type)]
-  def lookup(context: InferenceContext, name: String): Option[Type] =
+  type InferenceContext = List[(Name, Type)]
+  def lookup(context: InferenceContext, name: Name): Option[Type] =
     context.find(p => p._1 == name).map(_._2)
 
-  def extend(context: InferenceContext, name: String, typ: Type): InferenceContext =
+  def extend(context: InferenceContext, name: Name, typ: Type): InferenceContext =
     (name, typ) :: context
 
   def initVars: List[Var] = Nil
 
   lazy val emptyContext: InferenceContext = initVars map {
-    case Var(name, typ) => (name.toString, typ)
+    case Var(name, typ) => (name, typ)
   }
 
   sealed trait TypedTerm extends Product {
     def getType: Type
   }
-  case class TVar(name: String, typ: Type) extends TypedTerm {
+  case class TVar(name: Name, typ: Type) extends TypedTerm {
     override def getType = typ
   }
-  case class TAbs(argumentName: String, argumentType: Type, body: TypedTerm) extends TypedTerm {
+  case class TAbs(argumentName: Name, argumentType: Type, body: TypedTerm) extends TypedTerm {
     override def getType = =>:(argumentType, body.getType)
   }
   case class TApp(t1: TypedTerm, t2: TypedTerm, typ: Type) extends TypedTerm {
@@ -78,11 +78,11 @@ extends base.Syntax
   }
   //XXX this should be in LetInference, but let's not unseal stuff for now, that might break shapeless.
   //However, the handling is only
-  case class TLet(variable: String, varType: Type, exp: TypedTerm, body: TypedTerm) extends TypedTerm {
+  case class TLet(variable: Name, varType: Type, exp: TypedTerm, body: TypedTerm) extends TypedTerm {
     override def getType = body.getType
   }
-  case class TBinding(variable: String, varType: Type, exp: TypedTerm)
-  case class TLetRec(bindings: List[TBinding], bodyName: String, body: TypedTerm) extends TypedTerm {
+  case class TBinding(variable: Name, varType: Type, exp: TypedTerm)
+  case class TLetRec(bindings: List[TBinding], bodyName: Name, body: TypedTerm) extends TypedTerm {
     override def getType = body.getType
   }
 
@@ -222,7 +222,7 @@ trait LetInference extends Inference with LetUntypedSyntax with let.Syntax {
 trait LetRecInference extends Inference with LetRecUntypedSyntax with functions.LetRecSyntax {
   override def collectConstraints(term: UntypedTerm, context: InferenceContext = emptyContext): (TypedTerm, Set[Constraint]) = term match {
     case ULetRec(pairs, bodyName, body) =>
-      val tVars: List[(String, TypeVariable)] = pairs map (_._1) map ((_, freshTypeVariable(term)))
+      val tVars: List[(Name, TypeVariable)] = pairs map (_._1) map ((_, freshTypeVariable(term)))
       val extCtx = tVars.foldLeft(context) {
         (ctx, newTVar) => extend(ctx, newTVar._1, newTVar._2)
       }
@@ -239,7 +239,7 @@ trait LetRecInference extends Inference with LetRecUntypedSyntax with functions.
     case _ => super.collectConstraints(term, context)
   }
 
-  //  case class TLetRec(bindings: List[(String, Type, TypedTerm)], body: TypedTerm)
+  //  case class TLetRec(bindings: List[(Name, Type, TypedTerm)], body: TypedTerm)
 
   override def substitute(substitutions: Map[TypeVariable, Type], term: TypedTerm): TypedTerm = term match {
     case TLetRec(bindings, bodyName, body) =>

--- a/src/main/scala/ilc/feature/inference/Inference.scala
+++ b/src/main/scala/ilc/feature/inference/Inference.scala
@@ -65,7 +65,7 @@ extends base.Syntax
     override def getType = typ
   }
   case class TAbs(argumentName: Name, argumentType: Type, body: TypedTerm) extends TypedTerm {
-    override def getType = =>:(argumentType, body.getType)
+    override def getType = argumentType =>: body.getType
   }
   case class TApp(t1: TypedTerm, t2: TypedTerm, typ: Type) extends TypedTerm {
     override def getType = typ

--- a/src/main/scala/ilc/feature/inference/PrettySyntax.scala
+++ b/src/main/scala/ilc/feature/inference/PrettySyntax.scala
@@ -30,6 +30,7 @@ trait PrettySyntax extends Inference {
    * much work and I'm not sure it'd actually work).
    */
   implicit def symbolToUTOps(x: Symbol) = UTOps(x)
+  implicit def nameToUTOps(x: Name) = UTOps(x)
   implicit def stringToUTOps(x: String) = UTOps(x)
 
   case class TypeAnnotation(name: Name, typ: Type)
@@ -50,6 +51,8 @@ trait PrettySyntax extends Inference {
     def apply(that: UntypedTerm, more: UntypedTerm*): UApp =
       more.foldLeft(UApp(untypedTerm, that))((acc: UApp, arg: UntypedTerm) => UApp(acc, arg))
 
+    //I decided that TypeAnnotations and TypeAscriptions should be separate,
+    //but I'm less sure whether that's a good idea for the surface syntax. PG.
     def ofType(typ: Type): TypeAscription = TypeAscription(untypedTerm, typ)
 
     def composeWith(second: UntypedTerm): UntypedTerm =

--- a/src/main/scala/ilc/feature/inference/PrettySyntax.scala
+++ b/src/main/scala/ilc/feature/inference/PrettySyntax.scala
@@ -8,7 +8,8 @@ trait PrettySyntax extends Inference {
   implicit def polymorphicConstantToUPolymorphicConstant(x: PolymorphicConstant): UntypedTerm = UPolymorphicConstant(x)
   implicit def monomorphicConstantToUMonomorphicConstant(x: Term): UntypedTerm = UMonomorphicConstant(x)
   implicit def symbolToUVar(x: Symbol): UVar = UVar(x.name)
-  implicit def stringToUVar(x: String): UVar = UVar(x)
+  implicit def nameToUVar(x: Name): UVar = UVar(x)
+  implicit def stringToUVar(x: String): UVar = (x: Name): UVar
 
   /*
    * The point of this implicit conversion is to trigger ambiguity errors in

--- a/src/main/scala/ilc/feature/inference/PrettySyntax.scala
+++ b/src/main/scala/ilc/feature/inference/PrettySyntax.scala
@@ -32,7 +32,7 @@ trait PrettySyntax extends Inference {
   implicit def symbolToUTOps(x: Symbol) = UTOps(x)
   implicit def stringToUTOps(x: String) = UTOps(x)
 
-  case class TypeAnnotation(name: String, typ: Type)
+  case class TypeAnnotation(name: Name, typ: Type)
 
   implicit class UTOps[T <% UntypedTerm](untypedTerm: T) {
 
@@ -58,5 +58,8 @@ trait PrettySyntax extends Inference {
 
   implicit class SymbolOps(name: Symbol) {
     def %(typ: Type): TypeAnnotation = TypeAnnotation(name.name, typ)
+  }
+  implicit class NameOps(name: Name) {
+    def %(typ: Type): TypeAnnotation = TypeAnnotation(name, typ)
   }
 }

--- a/src/main/scala/ilc/feature/inference/PrettySyntax.scala
+++ b/src/main/scala/ilc/feature/inference/PrettySyntax.scala
@@ -48,6 +48,8 @@ trait PrettySyntax extends Inference {
       UAbs(param, None, untypedTerm)
 
     // Require at least one argument.
+    //XXX Names can't be applied because of a conflict between different
+    //implicit conversions.
     def apply(that: UntypedTerm, more: UntypedTerm*): UApp =
       more.foldLeft(UApp(untypedTerm, that))((acc: UApp, arg: UntypedTerm) => UApp(acc, arg))
 

--- a/src/main/scala/ilc/feature/inference/PrettySyntax.scala
+++ b/src/main/scala/ilc/feature/inference/PrettySyntax.scala
@@ -42,7 +42,7 @@ trait PrettySyntax extends Inference {
     def ->:(param: TypeAnnotation): UntypedTerm =
       UAbs(param.name, Some(param.typ), untypedTerm)
 
-    def ->:(param: String): UntypedTerm =
+    def ->:(param: Name): UntypedTerm =
       UAbs(param, None, untypedTerm)
 
     // Require at least one argument.

--- a/src/main/scala/ilc/feature/inference/UntypedSyntax.scala
+++ b/src/main/scala/ilc/feature/inference/UntypedSyntax.scala
@@ -7,8 +7,8 @@ trait UntypedSyntax {
 
   trait UntypedTerm
 
-  case class UVar(getName: String) extends UntypedTerm
-  case class UAbs(argumentName: String, typeAnnotation: Option[Type], body: UntypedTerm) extends UntypedTerm
+  case class UVar(getName: Name) extends UntypedTerm
+  case class UAbs(argumentName: Name, typeAnnotation: Option[Type], body: UntypedTerm) extends UntypedTerm
   case class UApp(operator: UntypedTerm, operand: UntypedTerm) extends UntypedTerm
   case class UMonomorphicConstant(term: Term) extends UntypedTerm
   case class UPolymorphicConstant(term: PolymorphicConstant) extends UntypedTerm
@@ -18,11 +18,11 @@ trait UntypedSyntax {
 trait LetUntypedSyntax extends UntypedSyntax {
   this: base.Syntax with functions.Syntax =>
 
-  case class ULet(variable: String, exp: UntypedTerm, body: UntypedTerm) extends UntypedTerm
+  case class ULet(variable: Name, exp: UntypedTerm, body: UntypedTerm) extends UntypedTerm
 }
 
 trait LetRecUntypedSyntax extends UntypedSyntax {
   this: base.Syntax with functions.Syntax =>
 
-  case class ULetRec(pairs: List[(String, UntypedTerm)], bodyName: String, body: UntypedTerm) extends UntypedTerm
+  case class ULetRec(pairs: List[(Name, UntypedTerm)], bodyName: Name, body: UntypedTerm) extends UntypedTerm
 }

--- a/src/main/scala/ilc/feature/let/ANormalForm.scala
+++ b/src/main/scala/ilc/feature/let/ANormalForm.scala
@@ -31,7 +31,7 @@ trait ANormalForm extends ANormalFormInterface {
   import mySyntax._
 
   private val freshGen = new base.FreshGen { lazy val syntax: mySyntax.type = mySyntax }
-  import freshGen._
+  import freshGen.fresh
 
   override def aNormalizeTerm(t: Term): Term = aNormalize(t)(identity)
   def aNormalize(t: Term)(k: Term => Term): Term = t match {
@@ -72,7 +72,7 @@ trait ANormalFormStateful extends ANormalFormInterface {
     //This must be lazy because at this time mySyntax is not initialized yet.
     lazy val syntax: mySyntax.type = mySyntax
   }
-  import freshGen._
+  import freshGen.fresh
 
   abstract class Bindings(var substs: immutable.Map[Var, Term]) {
     val bindings: mutable.Traversable[(Term, Var)] with Growable[(Term, Var)]
@@ -257,7 +257,7 @@ trait AddCaches2 {
     lazy val syntax: mySyntax.type = mySyntax
   }
   import aNormalizer._
-  import freshGen._
+  import freshGen.fresh
 
   def addCaches: Term => Term =
     t => extendReturns(aNormalizeTerm(t))

--- a/src/main/scala/ilc/feature/let/BetaReduction.scala
+++ b/src/main/scala/ilc/feature/let/BetaReduction.scala
@@ -27,7 +27,7 @@ trait BetaReduction extends Syntax with FreeVariables with analysis.Occurrences 
   }
   implicitly[freshGen.syntax.type =:= outer.type] //A type equality assertion.
   implicitly[freshGen.syntax.Term =:= outer.Term]
-  import freshGen._
+  import freshGen.fresh
 
   val shouldNormalize = true
 
@@ -63,7 +63,7 @@ trait BetaReduction extends Syntax with FreeVariables with analysis.Occurrences 
     //Let's run this to convergence.
     //Since I'm too lazy to implement alpha-equivalence testing, especially
     //in an efficient way, just reset the freshness index.
-    resetIndex()
+    freshGen.resetIndex()
     val u = normalizeEverywhereOnce(t)
     if (t == u)
       t

--- a/src/main/scala/ilc/feature/let/BetaReduction.scala
+++ b/src/main/scala/ilc/feature/let/BetaReduction.scala
@@ -83,6 +83,9 @@ trait BetaReduction extends Syntax with FreeVariables with analysis.Occurrences 
    * A "custom" implementation of normalization by evaluation.
    * The initial code was written and tested based on a faint recollection of the basic algorithm,
    * but it worked surprisingly well.
+   * Warning: this is completely syntax-directed, so it neither eta-expands not
+   * eta-reduces terms; in other words, it does not compute a beta-eta-normal form,
+   * only a beta-normal form.
    *
    * Unusual features:
    * - instead of producing standard normal forms, it performs let conversion and shrinking reductions.

--- a/src/main/scala/ilc/feature/let/BetaReduction.scala
+++ b/src/main/scala/ilc/feature/let/BetaReduction.scala
@@ -15,7 +15,7 @@ trait ProgramSize extends Syntax {
 
 trait BetaReduction extends Syntax with FreeVariables with analysis.Occurrences with Traversals with IsAtomic {
   outer =>
-  val freshGen = new base.FreshGen {
+  private val freshGen = new base.FreshGen {
     /*
      * The singleton type annotation encodes a "sharing constraint"*:
      * freshGen.syntax.type =:= outer.type. The typechecker can deduce then

--- a/src/main/scala/ilc/feature/let/BetaReduction.scala
+++ b/src/main/scala/ilc/feature/let/BetaReduction.scala
@@ -63,6 +63,7 @@ trait BetaReduction extends Syntax with FreeVariables with analysis.Occurrences 
     //Let's run this to convergence.
     //Since I'm too lazy to implement alpha-equivalence testing, especially
     //in an efficient way, just reset the freshness index.
+    //XXX now I did implement linear-time alpha-equivalence.
     freshGen.resetIndex()
     val u = normalizeEverywhereOnce(t)
     if (t == u)

--- a/src/main/scala/ilc/feature/let/CPS.scala
+++ b/src/main/scala/ilc/feature/let/CPS.scala
@@ -1,0 +1,30 @@
+package ilc
+package feature
+package let
+
+object CPS extends functions.Syntax {
+  outer =>
+
+  //An implementation of Plotkin's CBV CPS transformation.
+  case object AnswerT extends Type
+  def toCPST(t: Type) = (t =>: AnswerT) =>: AnswerT
+  def kVar(t: Term): Var = Var("k", toCPST(t.getType))
+
+  def toCPS: Term => Term = {
+    case t @ App(f, arg) =>
+      lambda(kVar(t))(k =>
+        toCPS(f) ! lambda(Var("a", f.getType))(a =>
+          toCPS(arg) ! lambda(Var("b", arg.getType))(b =>
+            a ! b ! k)))
+    /*
+     * Plotkin's paper has three separate identical cases. However, they are
+     * the same, and once one looks at how one does a CPS transformation by going
+     * to CBPV first, that becomes obvious: computations need to be
+     * sequentialized, while values simply need to be turned into trivial
+     * computations.
+     */
+    case value =>
+      val k = kVar(value)
+      Abs(k, App(k, value))
+  }
+}

--- a/src/main/scala/ilc/feature/let/CPS.scala
+++ b/src/main/scala/ilc/feature/let/CPS.scala
@@ -2,9 +2,13 @@ package ilc
 package feature
 package let
 
-object CPS extends functions.Syntax {
-  //An implementation of Plotkin-Fisher's CBV CPS transformation.
+//An implementation of Plotkin-Fisher's CBV CPS transformation.
+
+trait CPSTypes extends base.Types {
   case object AnswerT extends Type
+}
+
+trait CPS extends functions.Syntax with CPSTypes {
   def toCPST(t: Type) = (t =>: AnswerT) =>: AnswerT
   def kVar(t: Term): Var = Var("k", toCPST(t.getType))
 

--- a/src/main/scala/ilc/feature/let/CPS.scala
+++ b/src/main/scala/ilc/feature/let/CPS.scala
@@ -10,7 +10,8 @@ trait CPSTypes extends base.Types {
 
 //XXX: I can't import SyntaxSugar only, because it's written as a trait. If I
 //want to allow importing hierarchically, I need to write the module
-//differently! For modules with local state, that does make sense.
+//differently! For modules with local state, that does make sense, but less so for
+//hiding implicit conversions.
 trait CPS extends functions.Syntax with CPSTypes with inference.Inference /* XXX for traverse!*/ with inference.PrettySyntax {
   outer =>
   private val freshGen = new base.FreshGen { val syntax: outer.type = outer }

--- a/src/main/scala/ilc/feature/let/CPS.scala
+++ b/src/main/scala/ilc/feature/let/CPS.scala
@@ -8,16 +8,59 @@ trait CPSTypes extends base.Types {
   case object AnswerT extends Type
 }
 
-trait CPS extends functions.Syntax with CPSTypes {
-  def toCPST(t: Type) = (t =>: AnswerT) =>: AnswerT
-  def kVar(t: Term): Var = Var("k", toCPST(t.getType))
+//XXX: I can't import SyntaxSugar only, because it's written as a trait. If I
+//want to allow importing hierarchically, I need to write the module
+//differently! For modules with local state, that does make sense.
+trait CPS extends functions.Syntax with CPSTypes with inference.Inference /* XXX for traverse!*/ with inference.PrettySyntax {
+  outer =>
+  private val freshGen = new base.FreshGen { val syntax: outer.type = outer }
+  import freshGen.freshName
+  def cpsMonad(t: Type) =
+    (t =>: AnswerT) =>: AnswerT
 
-  def toCPS: Term => Term = {
+  //def argToCPS(tau: Type): Type = tau traverse toCPST
+  //def retToCPS(tau: Type): Type = ???
+
+  def toCPSTRec(tau: Type): Type =
+    tau traverse toCPSTRec match {
+      case s =>: t =>
+        //toCPST(s) =>: toCPST(t)
+        s =>: cpsMonad(t)
+        //retToCPS(t)
+      case t =>
+        t
+        //cpsMonad(t)
+    }
+  def toCPST(tau: Type): Type =
+    cpsMonad(toCPSTRec(tau))
+
+  def toCPSContType(t: Type) = {
+    //(t =>: AnswerT)
+    val v = toCPST(t)
+    println(v)
+    v match {
+      case src =>: dst =>
+        src
+    }
+  }
+
+  def kVar(t: Type): Var = Var(freshName("k"), t)
+
+  def toCPSU: Term => UntypedTerm = {
     case t @ App(f, arg) =>
-      lambda(kVar(t))(k =>
+      /*lambda(kVar(t))(k =>
         toCPS(f) ! lambda(Var("a", f.getType))(a =>
           toCPS(arg) ! lambda(Var("b", arg.getType))(b =>
-            a ! b ! k)))
+            a ! b ! k)))*/
+      val kV = freshName("k").toString
+      val aV = freshName("a").toString
+      val bV = freshName("b").toString
+      UAbs(kV, None,
+        UApp(toCPSU(f), UAbs(aV, None,
+          UApp(toCPSU(arg), UAbs(bV, None,
+            UApp(
+              UApp(aV, bV),
+              kV))))))
     /*
      * Plotkin's paper has three separate identical cases. However, they are
      * the same (ahem, save the recursive visit...), and once one looks at how
@@ -27,10 +70,43 @@ trait CPS extends functions.Syntax with CPSTypes {
      * computations.
      */
     case t @ Abs(v, body) =>
-      val k = kVar(t)
-      Abs(k, App(k, toCPS(body)))
+      val k = freshName("k").toString
+      UAbs(k, None,
+          UApp(k, UAbs(v.getName.toString, None, toCPSU(body))))
+    case Var(name, _) =>
+      val k = freshName("k").toString
+          //toCPSContType(value.getType)
+      UAbs(k, None, UApp(k, name.toString))
+  }
+  def toCPS: Term => Term = {
+    case t @ App(f, arg) =>
+      /*lambda(kVar(t))(k =>
+        toCPS(f) ! lambda(Var("a", f.getType))(a =>
+          toCPS(arg) ! lambda(Var("b", arg.getType))(b =>
+            a ! b ! k)))*/
+      val kV = kVar(toCPST(t.getType))
+      val aV = Var(freshName("a"), toCPSContType(f.getType))
+      val bV = Var(freshName("b"), toCPSContType(arg.getType))
+      Abs(kV,
+        App(toCPS(f), Abs(aV,
+          App(toCPS(arg), Abs(bV,
+            App(
+              App(aV, bV),
+              kV))))))
+    /*
+     * Plotkin's paper has three separate identical cases. However, they are
+     * the same (ahem, save the recursive visit...), and once one looks at how
+     * one does a CPS transformation by going
+     * to CBPV first, that becomes obvious: computations need to be
+     * sequentialized, while values simply need to be turned into trivial
+     * computations.
+     */
+    case t @ Abs(v, body) =>
+      val k = kVar(toCPST(t.getType))
+      Abs(k, App(k, Abs(v, toCPS(body))))
     case value =>
-      val k = kVar(value)
+      val k = kVar(value.getType =>: AnswerT)
+          //toCPSContType(value.getType)
       Abs(k, App(k, value))
   }
 }

--- a/src/main/scala/ilc/feature/let/CPS.scala
+++ b/src/main/scala/ilc/feature/let/CPS.scala
@@ -52,9 +52,9 @@ trait CPS extends functions.Syntax with CPSTypes with inference.Inference /* XXX
         toCPS(f) ! lambda(Var("a", f.getType))(a =>
           toCPS(arg) ! lambda(Var("b", arg.getType))(b =>
             a ! b ! k)))*/
-      val kV = freshName("k").toString
-      val aV = freshName("a").toString
-      val bV = freshName("b").toString
+      val kV = freshName("k")
+      val aV = freshName("a")
+      val bV = freshName("b")
       UAbs(kV, None,
         UApp(toCPSU(f), UAbs(aV, None,
           UApp(toCPSU(arg), UAbs(bV, None,
@@ -70,13 +70,13 @@ trait CPS extends functions.Syntax with CPSTypes with inference.Inference /* XXX
      * computations.
      */
     case t @ Abs(v, body) =>
-      val k = freshName("k").toString
+      val k = freshName("k")
       UAbs(k, None,
-          UApp(k, UAbs(v.getName.toString, None, toCPSU(body))))
+          UApp(k, UAbs(v.getName, None, toCPSU(body))))
     case Var(name, _) =>
-      val k = freshName("k").toString
+      val k = freshName("k")
           //toCPSContType(value.getType)
-      UAbs(k, None, UApp(k, name.toString))
+      UAbs(k, None, UApp(k, name))
   }
   def toCPS: Term => Term = {
     case t @ App(f, arg) =>

--- a/src/main/scala/ilc/feature/let/CPS.scala
+++ b/src/main/scala/ilc/feature/let/CPS.scala
@@ -3,8 +3,6 @@ package feature
 package let
 
 object CPS extends functions.Syntax {
-  outer =>
-
   //An implementation of Plotkin's CBV CPS transformation.
   case object AnswerT extends Type
   def toCPST(t: Type) = (t =>: AnswerT) =>: AnswerT
@@ -18,11 +16,15 @@ object CPS extends functions.Syntax {
             a ! b ! k)))
     /*
      * Plotkin's paper has three separate identical cases. However, they are
-     * the same, and once one looks at how one does a CPS transformation by going
+     * the same (ahem, save the recursive visit...), and once one looks at how
+     * one does a CPS transformation by going
      * to CBPV first, that becomes obvious: computations need to be
      * sequentialized, while values simply need to be turned into trivial
      * computations.
      */
+    case t @ Abs(v, body) =>
+      val k = kVar(t)
+      Abs(k, App(k, toCPS(body)))
     case value =>
       val k = kVar(value)
       Abs(k, App(k, value))

--- a/src/main/scala/ilc/feature/let/CPS.scala
+++ b/src/main/scala/ilc/feature/let/CPS.scala
@@ -3,7 +3,7 @@ package feature
 package let
 
 object CPS extends functions.Syntax {
-  //An implementation of Plotkin's CBV CPS transformation.
+  //An implementation of Plotkin-Fisher's CBV CPS transformation.
   case object AnswerT extends Type
   def toCPST(t: Type) = (t =>: AnswerT) =>: AnswerT
   def kVar(t: Term): Var = Var("k", toCPST(t.getType))

--- a/src/main/scala/ilc/feature/let/FullErasure.scala
+++ b/src/main/scala/ilc/feature/let/FullErasure.scala
@@ -12,10 +12,7 @@ trait FullErasure {
   //But whatever, the types are narrow enough to ensure needed recursive calls
   //are done.
 
-  def convName(n: Name) =
-    n.toString //XXX
-
-  def varName(v: Var) = convName(v.getName)
+  def varName(v: Var) = v.getName
   def fullErasure: Term => UntypedTerm = {
     case v: Var =>
       UVar(varName(v))

--- a/src/main/scala/ilc/feature/let/ToHaskell.scala
+++ b/src/main/scala/ilc/feature/let/ToHaskell.scala
@@ -10,7 +10,7 @@ trait ToHaskell {
 
   def untypedToHaskell: UntypedTerm => String = {
     case UVar(name) =>
-      name
+      name.toString
     case UApp(s, t) =>
       s"${untypedToHaskell(s)} ${untypedToHaskell(t)}"
     case UAbs(v, None, body) =>

--- a/src/main/scala/ilc/metaprogs/AlphaEquiv.scala
+++ b/src/main/scala/ilc/metaprogs/AlphaEquiv.scala
@@ -1,0 +1,46 @@
+package ilc
+package metaprogs
+
+import feature._
+
+trait AlphaEquiv {
+  outer: functions.Syntax =>
+  //Use custom name to avoid conflicts
+  protected val aeFreshGen = new base.FreshGen { val syntax: outer.type = outer }
+  import aeFreshGen.freshName
+
+  def alphaEquiv(t1: Term, t2: Term, ignoreTypes: Boolean = false): Boolean =
+    doAlphaEquiv(t1, t2, Map(), Map(), ignoreTypes)
+  //The maps should be from Name to Name
+  protected def doAlphaEquiv(t1: Term, t2: Term, map1: Map[Name, Name], map2: Map[Name, Name], ignoreTypes: Boolean): Boolean =
+    (t1, t2) match {
+      case (Abs(Var(n1, t1), body1), Abs(Var(n2, t2), body2)) =>
+        (ignoreTypes || t1 == t2) && {
+          val nNew = freshName(n1)
+          doAlphaEquiv(body1, body2, map1 + (n1 -> nNew), map2 + (n2 -> nNew), ignoreTypes)
+        }
+      case (App(f1, arg1), App(f2, arg2)) =>
+        doAlphaEquiv(f1, f2, map1, map2, ignoreTypes) && doAlphaEquiv(arg1, arg2, map1, map2, ignoreTypes)
+      case (v1 @ Var(n1, t1), v2 @ Var(n2, t2)) =>
+         (ignoreTypes || t1 == t2) && map1(n1) == map2(n2)
+      case _ => false
+    }
+}
+
+trait AlphaEquivLet extends AlphaEquiv {
+  outer: let.Syntax =>
+  import aeFreshGen.freshName
+
+  override protected def doAlphaEquiv(t1: Term, t2: Term, map1: Map[Name, Name], map2: Map[Name, Name], ignoreTypes: Boolean): Boolean =
+    (t1, t2) match {
+      case (Let(Var(n1, t1), e1, body1), Let(Var(n2, t2), e2, body2)) =>
+        (ignoreTypes || t1 == t2) &&
+        doAlphaEquiv(e1, e2, map1, map2, ignoreTypes) &&
+        {
+          val nNew = freshName(n1)
+          doAlphaEquiv(body1, body2, map1 + (n1 -> nNew), map2 + (n2 -> nNew), ignoreTypes)
+        }
+      case _ =>
+        super.doAlphaEquiv(t1, t2, map1, map2, ignoreTypes)
+    }
+}

--- a/src/test/scala/ilc/feature/cbpv/CBPVTest.sc
+++ b/src/test/scala/ilc/feature/cbpv/CBPVTest.sc
@@ -1,0 +1,22 @@
+package ilc
+package feature
+package cbpv
+
+object CBPVTest extends TypeConversions {
+  //println("Welcome to the Scala worksheet")
+  cbnTypeToCBPV(SumType(UnitType, UnitType))      //> res0: ilc.feature.cbpv.CBPVTest.CompType = FProducerCT(SumVT(UThunkVT(FProdu
+                                                  //| cerCT(UnitVT)),UThunkVT(FProducerCT(UnitVT))))
+  compTypeToType(cbnTypeToCBPV(BooleanType))      //> res1: ilc.feature.cbpv.CBPVTest.Type = F(( (1) + (1) ))
+  compTypeToType(cbnTypeToCBPV(BooleanType =>: BooleanType))
+                                                  //> res2: ilc.feature.cbpv.CBPVTest.Type = U(F(( (1) + (1) ))) -> F(( (1) + (1) 
+                                                  //| ))
+  compTypeToType(cbnTypeToCBPV(BooleanType =>: BooleanType =>: BooleanType))
+                                                  //> res3: ilc.feature.cbpv.CBPVTest.Type = U(F(( (1) + (1) ))) -> U(F(( (1) + (1
+                                                  //| ) ))) -> F(( (1) + (1) ))
+  valTypeToType(cbvTypeToCBPV(BooleanType =>: BooleanType =>: BooleanType))
+                                                  //> res4: ilc.feature.cbpv.CBPVTest.Type = U(( (1) + (1) ) -> F(U(( (1) + (1) ) 
+                                                  //| -> F(( (1) + (1) )))))
+  compTypeToType(cbnTypeToCBPV(UnitType =>: SumType(UnitType, UnitType)))
+                                                  //> res5: ilc.feature.cbpv.CBPVTest.Type = U(F(1)) -> F(( (U(F(1))) + (U(F(1))) 
+                                                  //| ))
+}

--- a/src/test/scala/ilc/feature/inference/InferenceSuite.scala
+++ b/src/test/scala/ilc/feature/inference/InferenceSuite.scala
@@ -59,7 +59,7 @@ with integers.Syntax
     val (typedTerm, constraints) = collectConstraints(UApp(id, id), List())
     val solved = unification(constraints)
     val finalTerm = substitute(solved, typedTerm)
-    assert(dropSourceInfo(finalTerm.getType) === =>:(TypeVariable(2), TypeVariable(2)))
+    assert(dropSourceInfo(finalTerm.getType) === (TypeVariable(2) =>: TypeVariable(2)))
   }
 }
 

--- a/src/test/scala/ilc/feature/let/ANormalFormSpec.scala
+++ b/src/test/scala/ilc/feature/let/ANormalFormSpec.scala
@@ -19,10 +19,10 @@ class ANormalFormSpec extends FlatSpec with Instantiations {
     */
     val test1 =
       letS(
-        'id -> ('x ->: 'x),
-        'id_i -> ('x ->: 'x),
-        'id_i2 -> ('x ->: 'x),
-        'apply -> ('f ->: 'x ->: 'f('x))
+        'id := ('x ->: 'x),
+        'id_i := ('x ->: 'x),
+        'id_i2 := ('x ->: 'x),
+        'apply := ('f ->: 'x ->: 'f('x))
       ) {
           'id('apply, 'id_i, 'id_i2(3: Term))
         }

--- a/src/test/scala/ilc/feature/let/ANormalFormTest.sc
+++ b/src/test/scala/ilc/feature/let/ANormalFormTest.sc
@@ -3,6 +3,7 @@ package feature
 package let
 
 object ANormalFormTest extends Instantiations {
+
   val v = buildBacchusWithLetSystem(true, true, true)
                                                   //> v  : ilc.language.Bacchus with ilc.feature.let.ANormalFormAdapter with ilc.f
                                                   //| eature.integers.ImplicitSyntaxSugar with ilc.feature.integers.Evaluation wit
@@ -11,7 +12,7 @@ object ANormalFormTest extends Instantiations {
                                                   //| erence.LetSyntaxSugar with ilc.feature.inference.InferenceTestHelper with il
                                                   //| c.feature.let.ShowTerms{val aNormalizer: ilc.feature.let.ANormalFormStateful
                                                   //| {val mySyntax: ilc.feature.let.Instantiations.<refinement>.type}} = ilc.feat
-                                                  //| ure.let.Instantiations$$anon$1@6c15f918
+                                                  //| ure.let.Instantiations$$anon$1@731a74c
   import v._
 
   //Taken from http://matt.might.net/articles/a-normalization/, but was ill-typed!
@@ -54,8 +55,8 @@ object ANormalFormTest extends Instantiations {
 */
   val test3 =
     let('x, ifThenElse(True, 1, 2): Term)('x)     //> test3  : ilc.feature.let.ANormalFormTest.v.UntypedTerm = ULet(x,UMonomorphic
-                                                  //| Constant(App(App(App(IfThenElse(ℤ),True),Abs(Var(unit,UnitType),LiteralInt
-                                                  //| (1))),Abs(Var(unit,UnitType),LiteralInt(2)))),UVar(x))
+                                                  //| Constant(App(App(App(IfThenElse(Z),True),Abs(Var(unit,1),LiteralInt(1))),Abs
+                                                  //| (Var(unit,1),LiteralInt(2)))),UVar(x))
   try {
     println(pretty(test1))
   } catch { case e: inference.Inference#UnificationFailure =>
@@ -164,7 +165,7 @@ object ANormalFormTest extends Instantiations {
                                                   //| a_9"
   show(test3)                                     //> res12: String = "
                                                   //| x =
-                                                  //|   IfThenElse(ℤ)
+                                                  //|   IfThenElse(Z)
                                                   //|     True
                                                   //|     (λunit.
                                                   //|        LiteralInt(1))
@@ -179,7 +180,7 @@ object ANormalFormTest extends Instantiations {
                                                   //|   λunit.
                                                   //|     LiteralInt(2);
                                                   //| a_12 =
-                                                  //|   IfThenElse(ℤ)
+                                                  //|   IfThenElse(Z)
                                                   //|     True
                                                   //|     a_10
                                                   //|     a_11;
@@ -192,7 +193,7 @@ object ANormalFormTest extends Instantiations {
                                                   //|   λunit_2.
                                                   //|     LiteralInt(2);
                                                   //| a_15 =
-                                                  //|   IfThenElse(ℤ)
+                                                  //|   IfThenElse(Z)
                                                   //|     True
                                                   //|     a_13
                                                   //|     a_14;

--- a/src/test/scala/ilc/feature/let/CPSPlay.sc
+++ b/src/test/scala/ilc/feature/let/CPSPlay.sc
@@ -2,118 +2,102 @@ package ilc
 package feature
 package let
 
-object CPSPlay extends Instantiations {
-
-  val v = buildBacchusWithLetSystem(true, true, true)
-                                                  //> v  : ilc.language.Bacchus with ilc.feature.let.ANormalFormAdapter with ilc.f
-                                                  //| eature.integers.ImplicitSyntaxSugar with ilc.feature.integers.Evaluation wit
-                                                  //| h ilc.feature.let.Evaluation with ilc.feature.let.Pretty with ilc.feature.le
-                                                  //| t.CPS with ilc.feature.cbpv.CBPVToCPS with ilc.feature.inference.LetInferenc
-                                                  //| e with ilc.feature.let.BetaReduction with ilc.feature.inference.LetSyntaxSug
-                                                  //| ar with ilc.feature.inference.InferenceTestHelper with ilc.feature.let.ShowT
-                                                  //| erms{val aNormalizer: ilc.feature.let.ANormalFormStateful{val mySyntax: ilc.
-                                                  //| feature.let.Instantiations.<refinement>.type}} = ilc.feature.let.Instantiati
-                                                  //| ons$$anon$1@731a74c
-
-  import v._
-  def testCPS(t: Term) = {
-    println(pretty(t))
-    val tau = t.getType
-    println(toCPST(tau))
-    println(cbvTypeToCPS(tau))
-    val untypedCPS = toCPSU(t)
-    println(untypedCPS)
-    println(pretty(untypedCPS))
-    println(pretty(toCPS(t)))
-  }                                               //> testCPS: (t: ilc.feature.let.CPSPlay.v.Term)Unit
-  testCPS('x ->: 'x)                              //> λx.
-                                                  //|   x
-                                                  //| ((T1 -> (T1 -> AnswerT) -> AnswerT) -> AnswerT) -> AnswerT
-                                                  //| (T1) x (T1 -> AnswerT) -> AnswerT
-                                                  //| UAbs(k_1,None,UApp(UVar(k_1),UAbs(x,None,UAbs(k_2,None,UApp(UVar(k_2),UVar(x
-                                                  //| ))))))
-                                                  //| λk_1lit.
-                                                  //|   k_1lit
-                                                  //|     (λx.
-                                                  //|      λk_2lit.
-                                                  //|        k_2lit
-                                                  //|          x)
-                                                  //| λk_3.
-                                                  //|   k_3
-                                                  //|     (λx.
+object CPSPlay extends CPSTestingHelper {
+  import bacchusSystem._
+  verboseShowTerm(normalize(tstA), "a")           //> Raw a term: Abs(Var(y_1,(T12 -> T13) -> T12),Abs(Var(x_2,T12 -> T13),App(Var
+                                                  //| (x_2,T12 -> T13),App(Var(y_1,(T12 -> T13) -> T12),Var(x_2,T12 -> T13)))))
+                                                  //| Pretty a term:
+                                                  //| λy_1.
+                                                  //| λx_2.
+                                                  //|   x_2
+                                                  //|     (y_1
+                                                  //|        x_2)
+                                                  //| Type: ((T12 -> T13) -> T12) -> (T12 -> T13) -> T13
+                                                  //| 
+  verboseShowTerm(normalize(tstB), "b")           //> Raw b term: Abs(Var(y_1,(T18 -> T19) -> T18),Abs(Var(x_2,T18 -> T19),App(Var
+                                                  //| (x_2,T18 -> T19),App(Var(y_1,(T18 -> T19) -> T18),Abs(Var(z_3,T18),App(Var(x
+                                                  //| _2,T18 -> T19),Var(z_3,T18)))))))
+                                                  //| Pretty b term:
+                                                  //| λy_1.
+                                                  //| λx_2.
+                                                  //|   x_2
+                                                  //|     (y_1
+                                                  //|        (λz_3.
+                                                  //|           x_2
+                                                  //|             z_3))
+                                                  //| Type: ((T18 -> T19) -> T18) -> (T18 -> T19) -> T19
+                                                  //| 
+  val tstAUnt = (toCPSU(tstA))('c ->: 'c)         //> tstAUnt  : ilc.feature.let.CPSPlay.bacchusSystem.UApp = UApp(UAbs(k_1,None,U
+                                                  //| App(UVar(k_1),UAbs(y,None,UAbs(k_2,None,UApp(UVar(k_2),UAbs(x,None,UAbs(k_3,
+                                                  //| None,UApp(UAbs(k_6,None,UApp(UVar(k_6),UVar(x))),UAbs(a_4,None,UApp(UAbs(k_7
+                                                  //| ,None,UApp(UAbs(k_10,None,UApp(UVar(k_10),UVar(y))),UAbs(a_8,None,UApp(UAbs(
+                                                  //| k_11,None,UApp(UVar(k_11),UVar(x))),UAbs(b_9,None,UApp(UApp(UVar(a_8),UVar(b
+                                                  //| _9)),UVar(k_7))))))),UAbs(b_5,None,UApp(UApp(UVar(a_4),UVar(b_5)),UVar(k_3))
+                                                  //| ))))))))))),UAbs(c,None,UVar(c)))
+  val tstBUnt = (toCPSU(tstB))('c ->: 'c)         //> tstBUnt  : ilc.feature.let.CPSPlay.bacchusSystem.UApp = UApp(UAbs(k_12,None,
+                                                  //| UApp(UVar(k_12),UAbs(y,None,UAbs(k_13,None,UApp(UVar(k_13),UAbs(x,None,UAbs(
+                                                  //| k_14,None,UApp(UAbs(k_17,None,UApp(UVar(k_17),UVar(x))),UAbs(a_15,None,UApp(
+                                                  //| UAbs(k_18,None,UApp(UAbs(k_21,None,UApp(UVar(k_21),UVar(y))),UAbs(a_19,None,
+                                                  //| UApp(UAbs(k_22,None,UApp(UVar(k_22),UAbs(z,None,UAbs(k_23,None,UApp(UAbs(k_2
+                                                  //| 6,None,UApp(UVar(k_26),UVar(x))),UAbs(a_24,None,UApp(UAbs(k_27,None,UApp(UVa
+                                                  //| r(k_27),UVar(z))),UAbs(b_25,None,UApp(UApp(UVar(a_24),UVar(b_25)),UVar(k_23)
+                                                  //| ))))))))),UAbs(b_20,None,UApp(UApp(UVar(a_19),UVar(b_20)),UVar(k_18))))))),U
+                                                  //| Abs(b_16,None,UApp(UApp(UVar(a_15),UVar(b_16)),UVar(k_14))))))))))))),UAbs(c
+                                                  //| ,None,UVar(c)))
+  verboseShowTerm(normalize(tstAUnt), "a I")      //> Raw a I term: Abs(Var(y_1,(T39 -> T24 -> T41) -> (T39 -> T41) -> T37),Abs(Va
+                                                  //| r(k_2,((T39 -> T24 -> T41) -> T24 -> T37) -> T44),App(Var(k_2,((T39 -> T24 -
+                                                  //| > T41) -> T24 -> T37) -> T44),Abs(Var(x_3,T39 -> T24 -> T41),Abs(Var(k_4,T24
+                                                  //| ),App(App(Var(y_1,(T39 -> T24 -> T41) -> (T39 -> T41) -> T37),Var(x_3,T39 ->
+                                                  //|  T24 -> T41)),Abs(Var(b_5,T39),App(App(Var(x_3,T39 -> T24 -> T41),Var(b_5,T3
+                                                  //| 9)),Var(k_4,T24)))))))))
+                                                  //| Pretty a I term:
+                                                  //| λy_1.
+                                                  //| λk_2.
+                                                  //|   k_2
+                                                  //|     (λx_3.
                                                   //|      λk_4.
-                                                  //|        k_4
-                                                  //|          x)
-  testCPS(Var("x", freshTypeVariable))            //> x
-                                                  //| (T7 -> AnswerT) -> AnswerT
-                                                  //| T7
-                                                  //| UAbs(k_5,None,UApp(UVar(k_5),UVar(x)))
-                                                  //| java.lang.RuntimeException: Unbound variable UVar(x)
-                                                  //| 	at scala.sys.package$.error(package.scala:27)
-                                                  //| 	at ilc.feature.inference.Inference$class.collectConstraints(Inference.sc
-                                                  //| ala:99)
-                                                  //| 	at ilc.feature.let.Instantiations$$anon$1.ilc$feature$inference$LetInfer
-                                                  //| ence$$super$collectConstraints(Instantiations.scala:14)
-                                                  //| 	at ilc.feature.inference.LetInference$class.collectConstraints(Inference
-                                                  //| .scala:207)
-                                                  //| 	at ilc.feature.let.Instantiations$$anon$1.collectConstraints(Instantiati
-                                                  //| ons.scala:14)
-                                                  //| 	at ilc.feature.inference.Inference$class.collectConstraints(Inference.sc
-                                                  //| ala:107)
-                                                  //| 	at ilc.feature.let.Instantiations$$anon$1.ilc$feature$inference$LetInfer
-                                                  //| ence$$super$collectConstraints(Instantiations.scala:14)
-                                                  //| 	at ilc.feature.inference.LetInference$class.collectConstraints(Inference
-                                                  //| .scala:207)
-                                                  //| 	at ilc.feature.let.Instantiations$$anon$1.collectConstraints(Instantiati
-                                                  //| ons.scala:14)
-                                                  //| 	at ilc.feature.inference.Inference$class.collectConstraints(Inference.sc
-                                                  //| ala:103)
-                                                  //| 	at ilc.feature.let.Instantiations$$anon$1.ilc$feature$inference$LetInfer
-                                                  //| ence$$super$collectConstraints(Instantiations.scala:14)
-                                                  //| 	at ilc.feature.inference.LetInference$class.collectConstraints(Inference
-                                                  //| .scala:207)
-                                                  //| 	at ilc.feature.let.Instantiations$$anon$1.collectConstraints(Instantiati
-                                                  //| ons.scala:14)
-                                                  //| 	at ilc.feature.inference.Inference$class.inferType(Inference.scala:191)
-                                                  //| 	at ilc.feature.let.Instantiations$$anon$1.inferType(Instantiations.scala
-                                                  //| :14)
-                                                  //| 	at ilc.feature.inference.PrettySyntax$class.untypedTermToTerm(PrettySynt
-                                                  //| ax.scala:7)
-                                                  //| 	at ilc.feature.let.Instantiations$$anon$1.untypedTermToTerm(Instantiatio
-                                                  //| ns.scala:14)
-                                                  //| 	at ilc.feature.let.CPSPlay$$anonfun$main$1.testCPS$1(ilc.feature.let.CPS
-                                                  //| Play.scala:17)
-                                                  //| 	at ilc.feature.let.CPSPlay$$anonfun$main$1.apply$mcV$sp(ilc.feature.let.
-                                                  //| CPSPlay.scala:21)
-                                                  //| 	at org.scalaide.worksheet.runtime.library.WorksheetSupport$$anonfun$$exe
-                                                  //| cute$1.apply$mcV$sp(WorksheetSupport.scala:76)
-                                                  //| 	at org.scalaide.worksheet.runtime.library.WorksheetSupport$.redirected(W
-                                                  //| orksheetSupport.scala:65)
-                                                  //| 	at org.scalaide.worksheet.runtime.library.WorksheetSupport$.$execute(Wor
-                                                  //| ksheetSupport.scala:75)
-                                                  //| 	at ilc.feature.let.CPSPlay$.main(ilc.feature.let.CPSPlay.scala:5)
-                                                  //| 	at ilc.feature.let.CPSPlay.main(ilc.feature.let.CPSPlay.scala)
-  val tst0 = asTerm('x ->: 'x)
-  println(pretty(tst0))
+                                                  //|        y_1
+                                                  //|          x_3
+                                                  //|          (λb_5.
+                                                  //|             x_3
+                                                  //|               b_5
+                                                  //|               k_4))
+                                                  //| Type: ((T39 -> T24 -> T41) -> (T39 -> T41) -> T37) -> (((T39 -> T24 -> T41) 
+                                                  //| -> T24 -> T37) -> T44) -> T44
+                                                  //| 
+  verboseShowTerm(normalize(tstBUnt), "b I")      //> Raw b I term: Abs(Var(y_1,(T68 -> T62 -> T71) -> (T68 -> T71) -> T76),Abs(Va
+                                                  //| r(k_2,((T68 -> T62 -> T71) -> T62 -> T76) -> T84),App(Var(k_2,((T68 -> T62 -
+                                                  //| > T71) -> T62 -> T76) -> T84),Abs(Var(x_3,T68 -> T62 -> T71),Abs(Var(k_4,T62
+                                                  //| ),App(App(Var(y_1,(T68 -> T62 -> T71) -> (T68 -> T71) -> T76),Abs(Var(z_5,T6
+                                                  //| 8),Abs(Var(k_6,T62),App(App(Var(x_3,T68 -> T62 -> T71),Var(z_5,T68)),Var(k_6
+                                                  //| ,T62))))),Abs(Var(b_7,T68),App(App(Var(x_3,T68 -> T62 -> T71),Var(b_7,T68)),
+                                                  //| Var(k_4,T62)))))))))
+                                                  //| Pretty b I term:
+                                                  //| λy_1.
+                                                  //| λk_2.
+                                                  //|   k_2
+                                                  //|     (λx_3.
+                                                  //|      λk_4.
+                                                  //|        y_1
+                                                  //|          (λz_5.
+                                                  //|           λk_6.
+                                                  //|             x_3
+                                                  //|               z_5
+                                                  //|               k_6)
+                                                  //|          (λb_7.
+                                                  //|             x_3
+                                                  //|               b_7
+                                                  //|               k_4))
+                                                  //| Type: ((T68 -> T62 -> T71) -> (T68 -> T71) -> T76) -> (((T68 -> T62 -> T71) 
+                                                  //| -> T62 -> T76) -> T84) -> T84
+                                                  //| 
   
-  tst0.getType
-  println(toCPST(tst0.getType))
-  println(cbvTypeToCPS(tst0.getType))
-  
-  println(pretty(toCPS(tst0)))
-  println(pretty(toCPSU(tst0)))
- 
-  val tst1 = asTerm('f ->: 'x ->: 'f('x))
-  println(pretty(tst1))
-
-  tst1.getType
-  println(toCPST(tst1.getType))
-  println(cbvTypeToCPS(tst1.getType))
-  val tst1Cps = asTerm(toCPSU(tst1))
-  println(pretty(tst1Cps))
-  println(pretty(toCPS(tst1)))
-  
-  val tst = asTerm('f ->: 'x ->: 'y ->: 'f('y)('x))
-  pretty(tst)
-  toCPS(tst)
+  //          x_3
+  // in the above term becomes
+  //          (λz_5.
+  //           λk_6.
+  //             x_3
+  //               z_5
+  //               k_6)
+  // because it gets eta-expanded and CPS-transformed
 }

--- a/src/test/scala/ilc/feature/let/CPSPlay.sc
+++ b/src/test/scala/ilc/feature/let/CPSPlay.sc
@@ -1,0 +1,119 @@
+package ilc
+package feature
+package let
+
+object CPSPlay extends Instantiations {
+
+  val v = buildBacchusWithLetSystem(true, true, true)
+                                                  //> v  : ilc.language.Bacchus with ilc.feature.let.ANormalFormAdapter with ilc.f
+                                                  //| eature.integers.ImplicitSyntaxSugar with ilc.feature.integers.Evaluation wit
+                                                  //| h ilc.feature.let.Evaluation with ilc.feature.let.Pretty with ilc.feature.le
+                                                  //| t.CPS with ilc.feature.cbpv.CBPVToCPS with ilc.feature.inference.LetInferenc
+                                                  //| e with ilc.feature.let.BetaReduction with ilc.feature.inference.LetSyntaxSug
+                                                  //| ar with ilc.feature.inference.InferenceTestHelper with ilc.feature.let.ShowT
+                                                  //| erms{val aNormalizer: ilc.feature.let.ANormalFormStateful{val mySyntax: ilc.
+                                                  //| feature.let.Instantiations.<refinement>.type}} = ilc.feature.let.Instantiati
+                                                  //| ons$$anon$1@731a74c
+
+  import v._
+  def testCPS(t: Term) = {
+    println(pretty(t))
+    val tau = t.getType
+    println(toCPST(tau))
+    println(cbvTypeToCPS(tau))
+    val untypedCPS = toCPSU(t)
+    println(untypedCPS)
+    println(pretty(untypedCPS))
+    println(pretty(toCPS(t)))
+  }                                               //> testCPS: (t: ilc.feature.let.CPSPlay.v.Term)Unit
+  testCPS('x ->: 'x)                              //> λx.
+                                                  //|   x
+                                                  //| ((T1 -> (T1 -> AnswerT) -> AnswerT) -> AnswerT) -> AnswerT
+                                                  //| (T1) x (T1 -> AnswerT) -> AnswerT
+                                                  //| UAbs(k_1,None,UApp(UVar(k_1),UAbs(x,None,UAbs(k_2,None,UApp(UVar(k_2),UVar(x
+                                                  //| ))))))
+                                                  //| λk_1lit.
+                                                  //|   k_1lit
+                                                  //|     (λx.
+                                                  //|      λk_2lit.
+                                                  //|        k_2lit
+                                                  //|          x)
+                                                  //| λk_3.
+                                                  //|   k_3
+                                                  //|     (λx.
+                                                  //|      λk_4.
+                                                  //|        k_4
+                                                  //|          x)
+  testCPS(Var("x", freshTypeVariable))            //> x
+                                                  //| (T7 -> AnswerT) -> AnswerT
+                                                  //| T7
+                                                  //| UAbs(k_5,None,UApp(UVar(k_5),UVar(x)))
+                                                  //| java.lang.RuntimeException: Unbound variable UVar(x)
+                                                  //| 	at scala.sys.package$.error(package.scala:27)
+                                                  //| 	at ilc.feature.inference.Inference$class.collectConstraints(Inference.sc
+                                                  //| ala:99)
+                                                  //| 	at ilc.feature.let.Instantiations$$anon$1.ilc$feature$inference$LetInfer
+                                                  //| ence$$super$collectConstraints(Instantiations.scala:14)
+                                                  //| 	at ilc.feature.inference.LetInference$class.collectConstraints(Inference
+                                                  //| .scala:207)
+                                                  //| 	at ilc.feature.let.Instantiations$$anon$1.collectConstraints(Instantiati
+                                                  //| ons.scala:14)
+                                                  //| 	at ilc.feature.inference.Inference$class.collectConstraints(Inference.sc
+                                                  //| ala:107)
+                                                  //| 	at ilc.feature.let.Instantiations$$anon$1.ilc$feature$inference$LetInfer
+                                                  //| ence$$super$collectConstraints(Instantiations.scala:14)
+                                                  //| 	at ilc.feature.inference.LetInference$class.collectConstraints(Inference
+                                                  //| .scala:207)
+                                                  //| 	at ilc.feature.let.Instantiations$$anon$1.collectConstraints(Instantiati
+                                                  //| ons.scala:14)
+                                                  //| 	at ilc.feature.inference.Inference$class.collectConstraints(Inference.sc
+                                                  //| ala:103)
+                                                  //| 	at ilc.feature.let.Instantiations$$anon$1.ilc$feature$inference$LetInfer
+                                                  //| ence$$super$collectConstraints(Instantiations.scala:14)
+                                                  //| 	at ilc.feature.inference.LetInference$class.collectConstraints(Inference
+                                                  //| .scala:207)
+                                                  //| 	at ilc.feature.let.Instantiations$$anon$1.collectConstraints(Instantiati
+                                                  //| ons.scala:14)
+                                                  //| 	at ilc.feature.inference.Inference$class.inferType(Inference.scala:191)
+                                                  //| 	at ilc.feature.let.Instantiations$$anon$1.inferType(Instantiations.scala
+                                                  //| :14)
+                                                  //| 	at ilc.feature.inference.PrettySyntax$class.untypedTermToTerm(PrettySynt
+                                                  //| ax.scala:7)
+                                                  //| 	at ilc.feature.let.Instantiations$$anon$1.untypedTermToTerm(Instantiatio
+                                                  //| ns.scala:14)
+                                                  //| 	at ilc.feature.let.CPSPlay$$anonfun$main$1.testCPS$1(ilc.feature.let.CPS
+                                                  //| Play.scala:17)
+                                                  //| 	at ilc.feature.let.CPSPlay$$anonfun$main$1.apply$mcV$sp(ilc.feature.let.
+                                                  //| CPSPlay.scala:21)
+                                                  //| 	at org.scalaide.worksheet.runtime.library.WorksheetSupport$$anonfun$$exe
+                                                  //| cute$1.apply$mcV$sp(WorksheetSupport.scala:76)
+                                                  //| 	at org.scalaide.worksheet.runtime.library.WorksheetSupport$.redirected(W
+                                                  //| orksheetSupport.scala:65)
+                                                  //| 	at org.scalaide.worksheet.runtime.library.WorksheetSupport$.$execute(Wor
+                                                  //| ksheetSupport.scala:75)
+                                                  //| 	at ilc.feature.let.CPSPlay$.main(ilc.feature.let.CPSPlay.scala:5)
+                                                  //| 	at ilc.feature.let.CPSPlay.main(ilc.feature.let.CPSPlay.scala)
+  val tst0 = asTerm('x ->: 'x)
+  println(pretty(tst0))
+  
+  tst0.getType
+  println(toCPST(tst0.getType))
+  println(cbvTypeToCPS(tst0.getType))
+  
+  println(pretty(toCPS(tst0)))
+  println(pretty(toCPSU(tst0)))
+ 
+  val tst1 = asTerm('f ->: 'x ->: 'f('x))
+  println(pretty(tst1))
+
+  tst1.getType
+  println(toCPST(tst1.getType))
+  println(cbvTypeToCPS(tst1.getType))
+  val tst1Cps = asTerm(toCPSU(tst1))
+  println(pretty(tst1Cps))
+  println(pretty(toCPS(tst1)))
+  
+  val tst = asTerm('f ->: 'x ->: 'y ->: 'f('y)('x))
+  pretty(tst)
+  toCPS(tst)
+}

--- a/src/test/scala/ilc/feature/let/CPSSpec.scala
+++ b/src/test/scala/ilc/feature/let/CPSSpec.scala
@@ -25,14 +25,14 @@ trait CPSTestingHelper extends Instantiations {
 
     println("Typed CPS transformation without type inference")
 
-    val cpsTau = toCPST(typ)
+    val cpsTau = cpsTransformType(typ)
     println(s"Expected CPS result type: ${cpsTau}")
     println(s"Unifying result of type inference with expected type: ${unification(Set(Constraint(cpsInferredType, cpsTau, "")))}")
 
     val typedCPS = toCPS(t)
     verboseShowTerm(typedCPS, "typed CPS")
     //XXX how do I reuse this inside and outside tests elegantly (that is, without the kludge of abstracting over assert)?
-    assert(cpsTau == toCPST(typ))
+    assert(cpsTau == cpsTransformType(typ))
   }
 
   val examples: List[Term] =

--- a/src/test/scala/ilc/feature/let/CPSSpec.scala
+++ b/src/test/scala/ilc/feature/let/CPSSpec.scala
@@ -11,6 +11,7 @@ trait CPSTestingHelper extends Instantiations {
   def testCPS(t: Term, callToCps: Boolean = true) = {
     val typ = t.getType
     verboseShowTerm(t, "source")
+    assert(alphaEquiv(t, normalize(t)))
 
 //    println(s"Type from CBPV CPS transformation: ${cbvTypeToCPS(typ)}")
 //    println()
@@ -34,13 +35,21 @@ trait CPSTestingHelper extends Instantiations {
     verboseShowTerm(typedCPS, "typed CPS")
     //XXX how do I reuse this inside and outside tests elegantly (that is, without the kludge of abstracting over assert)?
     assert(cpsTau == cpsTransformType(typ))
-    verboseShowTerm(normalize(typedCPS), "normalized typed CPS")
+    val normTypedCPS = normalize(typedCPS)
+    verboseShowTerm(normTypedCPS, "normalized typed CPS")
     println()
 
     println("One-step untyped CPS transformation plus type inference")
     val untypedCPSOnePass = toCPSUntypedOnePass(t)
     verboseShowTerm(untypedCPSOnePass, "one-step untyped CPS")
-    verboseShowTerm(normalize(untypedCPSOnePass), "normalized one-step untyped CPS")
+    val untypedCPSOnePassNorm = normalize(untypedCPSOnePass)
+    verboseShowTerm(untypedCPSOnePass, "normalized one-step untyped CPS")
+    assert(alphaEquiv(untypedCPSOnePass, untypedCPSOnePassNorm))
+    assert(alphaEquiv(untypedCPSOnePass, normTypedCPS, true))
+
+    val cpsOnePassInferredType = untypedCPSOnePass.getType
+    val unificationRes2 = unification(Set(Constraint(cpsOnePassInferredType, cpsTau, "")))
+    println(s"Unifying result of type inference with expected type: ${unificationRes2}")
   }
 
   val examples: List[Term] =

--- a/src/test/scala/ilc/feature/let/CPSSpec.scala
+++ b/src/test/scala/ilc/feature/let/CPSSpec.scala
@@ -43,13 +43,19 @@ trait CPSTestingHelper extends Instantiations {
     val untypedCPSOnePass = toCPSUntypedOnePass(t)
     verboseShowTerm(untypedCPSOnePass, "one-step untyped CPS")
     val untypedCPSOnePassNorm = normalize(untypedCPSOnePass)
-    verboseShowTerm(untypedCPSOnePass, "normalized one-step untyped CPS")
+//    verboseShowTerm(untypedCPSOnePassNorm, "normalized one-step untyped CPS")
     assert(alphaEquiv(untypedCPSOnePass, untypedCPSOnePassNorm))
     assert(alphaEquiv(untypedCPSOnePass, normTypedCPS, true))
 
     val cpsOnePassInferredType = untypedCPSOnePass.getType
     val unificationRes2 = unification(Set(Constraint(cpsOnePassInferredType, cpsTau, "")))
     println(s"Unifying result of type inference with expected type: ${unificationRes2}")
+
+    println("One-step typed CPS transformation without type inference")
+    val typedCPSOnePass = toCPSOnePass(t)
+    verboseShowTerm(typedCPSOnePass, "one-step typed CPS")
+    val typedCPSOnePassNorm = normalize(typedCPSOnePass)
+    assert(alphaEquiv(typedCPSOnePassNorm, typedCPSOnePass))
   }
 
   val examples: List[Term] =

--- a/src/test/scala/ilc/feature/let/CPSSpec.scala
+++ b/src/test/scala/ilc/feature/let/CPSSpec.scala
@@ -1,0 +1,19 @@
+package ilc
+package feature
+package let
+
+import org.scalatest._
+
+class CPSSpec extends FlatSpec with Instantiations {
+  val bacchusSystem = buildBacchusWithLetSystem(true, true, true)
+  import bacchusSystem._
+
+  "cps" should "work" in {
+    val tst1 = asTerm('f ->: 'x ->: 'f('x))
+    println(pretty(tst1))
+    println(tst1.getType)
+    println(toCPST(tst1.getType))
+    println(cbvTypeToCPS(tst1.getType))
+    println(pretty(toCPS(tst1)))
+  }
+}

--- a/src/test/scala/ilc/feature/let/CPSSpec.scala
+++ b/src/test/scala/ilc/feature/let/CPSSpec.scala
@@ -12,27 +12,35 @@ trait CPSTestingHelper extends Instantiations {
     val typ = t.getType
     verboseShowTerm(t, "source")
 
-    println(s"Type from CBPV CPS transformation: ${cbvTypeToCPS(typ)}")
-    println()
-
-    println("Untyped CPS transformation plus type inference")
+//    println(s"Type from CBPV CPS transformation: ${cbvTypeToCPS(typ)}")
+//    println()
+//
+//    println("Untyped CPS transformation plus type inference")
 
     val untypedCPS = asTerm(toCPSU(t)) //XXX without asTerm, inference will be repeated (and give equivalent but different results).
     val cpsInferredType = untypedCPS.getType
 
-    verboseShowTerm(untypedCPS, "untyped CPS")
-    println()
+//    verboseShowTerm(untypedCPS, "untyped CPS")
+//    println()
 
     println("Typed CPS transformation without type inference")
 
     val cpsTau = cpsTransformType(typ)
     println(s"Expected CPS result type: ${cpsTau}")
-    println(s"Unifying result of type inference with expected type: ${unification(Set(Constraint(cpsInferredType, cpsTau, "")))}")
+    val unificationRes = unification(Set(Constraint(cpsInferredType, cpsTau, "")))
+    println(s"Unifying result of type inference with expected type: ${unificationRes}")
 
     val typedCPS = toCPS(t)
     verboseShowTerm(typedCPS, "typed CPS")
     //XXX how do I reuse this inside and outside tests elegantly (that is, without the kludge of abstracting over assert)?
     assert(cpsTau == cpsTransformType(typ))
+    verboseShowTerm(normalize(typedCPS), "normalized typed CPS")
+    println()
+
+    println("One-step untyped CPS transformation plus type inference")
+    val untypedCPSOnePass = toCPSUntypedOnePass(t)
+    verboseShowTerm(untypedCPSOnePass, "one-step untyped CPS")
+    verboseShowTerm(normalize(untypedCPSOnePass), "normalized one-step untyped CPS")
   }
 
   val examples: List[Term] =

--- a/src/test/scala/ilc/feature/let/Instantiations.scala
+++ b/src/test/scala/ilc/feature/let/Instantiations.scala
@@ -23,6 +23,7 @@ trait Instantiations {
     new language.Bacchus with let.ANormalFormAdapter with integers.ImplicitSyntaxSugar
       with integers.Evaluation with let.Evaluation with let.Pretty
       with let.CPS with cbpv.CBPVToCPS //XXX added to also test CPS in worksheets
+      with metaprogs.AlphaEquivLet
       with inference.LetInference
       with BetaReduction with inference.LetSyntaxSugar with inference.InferenceTestHelper with ShowTerms {
         outer =>

--- a/src/test/scala/ilc/feature/let/Instantiations.scala
+++ b/src/test/scala/ilc/feature/let/Instantiations.scala
@@ -7,6 +7,15 @@ trait ShowTerms {
 
   def show(t: Term) =
     "\n" + pretty(t)
+
+  def verboseShowTerm(t: Term, qual: String) =
+    println(
+      s"""|Raw $qual term: ${t}
+          |Pretty $qual term:
+          |${pretty(t)}
+          |Type: ${t.getType}
+          |""".stripMargin)
+
 }
 
 trait Instantiations {

--- a/src/test/scala/ilc/feature/let/Instantiations.scala
+++ b/src/test/scala/ilc/feature/let/Instantiations.scala
@@ -13,6 +13,7 @@ trait Instantiations {
   def buildBacchusWithLetSystem(doCSE_ : Boolean, copyPropagation_ : Boolean, partialApplicationsAreSpecial_ : Boolean) =
     new language.Bacchus with let.ANormalFormAdapter with integers.ImplicitSyntaxSugar
       with integers.Evaluation with let.Evaluation with let.Pretty
+      with let.CPS with cbpv.CBPVToCPS //XXX added to also test CPS in worksheets
       with inference.LetInference
       with BetaReduction with inference.LetSyntaxSugar with inference.InferenceTestHelper with ShowTerms {
         outer =>


### PR DESCRIPTION
Not to merge yet. Agda is more suited to prototyping this code, thanks to totality checking.