### PR TITLE
Use alpha equivalence in BetaReduction (fix #11)

### DIFF
--- a/src/main/scala/ilc/feature/base/Syntax.scala
+++ b/src/main/scala/ilc/feature/base/Syntax.scala
@@ -185,14 +185,14 @@ Please do not declare getType as an abstract `val`.
     }
 
     def getConstantName: String = {
-        // objectName = "ilc.feature.maps.Lookup$" for example
-        val objectName = theConstant.getClass.getName
-        // simpleName = "Lookup"
-        // we can't use java.lang.Class.getSimpleName because
-        // it throws java.lang.InternalError: Malformed class name
-        // at java.lang.Class.getSimpleName(Class.java:1153)
-        // (java version "1.7.0_05")
-        objectName split """[\.\$]""" last
+      // objectName = "ilc.feature.maps.Lookup$" for example
+      val objectName = theConstant.getClass.getName
+      // simpleName = "Lookup"
+      // we can't use java.lang.Class.getSimpleName because
+      // it throws java.lang.InternalError: Malformed class name
+      // at java.lang.Class.getSimpleName(Class.java:1153)
+      // (java version "1.7.0_05")
+      objectName split """[\.\$]""" last
     }
   }
 

--- a/src/main/scala/ilc/feature/let/BetaReduction.scala
+++ b/src/main/scala/ilc/feature/let/BetaReduction.scala
@@ -13,7 +13,7 @@ trait ProgramSize extends Syntax {
   }
 }
 
-trait BetaReduction extends Syntax with FreeVariables with analysis.Occurrences with Traversals with IsAtomic {
+trait BetaReduction extends Syntax with FreeVariables with analysis.Occurrences with Traversals with IsAtomic with metaprogs.AlphaEquivLet {
   outer =>
   private val freshGen = new base.FreshGen {
     /*
@@ -61,12 +61,8 @@ trait BetaReduction extends Syntax with FreeVariables with analysis.Occurrences 
     //Because of how usage counts are computed (before normalization), this is not idempotent.
     //That's also typical in shrinking reductions.
     //Let's run this to convergence.
-    //Since I'm too lazy to implement alpha-equivalence testing, especially
-    //in an efficient way, just reset the freshness index.
-    //XXX now I did implement linear-time alpha-equivalence.
-    freshGen.resetIndex()
     val u = normalizeEverywhereOnce(t)
-    if (t == u)
+    if (alphaEquiv(t, u))
       t
     else
       doNormalize(u)

--- a/src/main/scala/ilc/feature/let/BetaReduction.scala
+++ b/src/main/scala/ilc/feature/let/BetaReduction.scala
@@ -57,7 +57,7 @@ trait BetaReduction extends Syntax with FreeVariables with analysis.Occurrences 
     reify(eval(t, Map.empty))
   }
 
-  def doNormalize(t: Term): Term = {
+  @annotation.tailrec final def doNormalize(t: Term): Term = {
     //Because of how usage counts are computed (before normalization), this is not idempotent.
     //That's also typical in shrinking reductions.
     //Let's run this to convergence.
@@ -69,7 +69,7 @@ trait BetaReduction extends Syntax with FreeVariables with analysis.Occurrences 
     if (t == u)
       t
     else
-      normalize(u)
+      doNormalize(u)
   }
 
   def normalize(t: Term) =

--- a/src/main/scala/ilc/metaprogs/AlphaEquiv.scala
+++ b/src/main/scala/ilc/metaprogs/AlphaEquiv.scala
@@ -23,7 +23,12 @@ trait AlphaEquiv {
         doAlphaEquiv(f1, f2, map1, map2, ignoreTypes) && doAlphaEquiv(arg1, arg2, map1, map2, ignoreTypes)
       case (v1 @ Var(n1, t1), v2 @ Var(n2, t2)) =>
          (ignoreTypes || t1 == t2) && map1(n1) == map2(n2)
-      case _ => false
+      case (Constant(pc1, tt1), Constant(pc2, tt2)) =>
+        pc1 == pc2 && (ignoreTypes || tt1 == tt2)
+      case _ =>
+        //Remaining values, that do *not* include type arguments.
+        //So this *will* ignore types.
+        t1 == t2
     }
 }
 

--- a/src/test/scala/ilc/feature/inference/PrettySuite.scala
+++ b/src/test/scala/ilc/feature/inference/PrettySuite.scala
@@ -15,7 +15,7 @@ trait ClashingImplicitConversion {
 
 class PrettySuite
 extends FlatSpec
-   with PrettySyntax
+   with SyntaxSugar
    with ilc.feature.maps.Syntax
    with ilc.feature.integers.Syntax
    with ilc.util.EvalScala
@@ -85,9 +85,8 @@ extends FlatSpec
   }
 
   it should "work when even more complicated" in {
-    val foldGroup: UntypedTerm = FoldGroup // from bags
-    val liftGroup: UntypedTerm = LiftGroup // own apply // from abelianMaps
-    val singletonMap: UntypedTerm = SingletonMap // from abelianMaps
+    val liftGroup = asUntyped(LiftGroup) // own apply // from abelianMaps
+    val singletonMap = asUntyped(SingletonMap) // from abelianMaps
 
     assert(
       'f ->: 'g ->: foldGroup(liftGroup(freeAbelianGroup),

--- a/src/test/scala/ilc/metaprogs/AlphaEquivSpec.scala
+++ b/src/test/scala/ilc/metaprogs/AlphaEquivSpec.scala
@@ -4,24 +4,77 @@ package metaprogs
 import org.scalatest._
 import feature._
 
-class AlphaEquivSpec extends FlatSpec with Matchers with AlphaEquiv with inference.SyntaxSugar {
+class AlphaEquivSpec extends FlatSpec
+    with integers.ImplicitSyntaxSugar
+    with let.Syntax
+    with inference.PrettySyntax with inference.LetSyntaxSugar
+    with inference.LetInference
+
+    with ilc.feature.maps.Syntax
+    with ilc.feature.bags.StdLib
+    with ilc.feature.abelianMaps.Syntax
+
+    with AlphaEquivLet {
   def shouldBeAlphaEquiv(t1: Term, t2: Term, ignoreTypes: Boolean = false) =
     assert(alphaEquiv(t1, t2, ignoreTypes))
 
   def shouldBeAlphaDiff(t1: Term, t2: Term, ignoreTypes: Boolean = false) =
     assert(!alphaEquiv(t1, t2, ignoreTypes))
 
-  "alpha-equivalence" should "identify equal terms" in {
-    val t = asTerm('x ->: 'x)
+  val idUt = 'x ->: 'x
+  val ut1 = letS('x := ifThenElse_(True, asTerm(1), asTerm(2)))('x)
+
+  //XXX from PrettySuite
+  val liftGroup = asUntyped(LiftGroup) // own apply // from abelianMaps
+  val singletonMap = asUntyped(SingletonMap) // from abelianMaps
+
+  val ut2 = 'x ->: 'y ->: letS('z := ifThenElse_(True, 'x, 'y))('z)
+  val ut3 = 'f ->: 'g ->: foldGroup(liftGroup(freeAbelianGroup),
+    'e ->: singletonMap('f('e), singleton('g('e))))
+
+  val ut4 = letS('x := ifThenElse_(True, asTerm(1), asTerm(2)))('x)
+
+  "alpha-equivalence" should "identify identical terms (even when ignoring types)" in {
+    //asTerm triggers type inference once:
+    val t = asTerm(idUt)
     shouldBeAlphaEquiv(t, t)
+    shouldBeAlphaEquiv(t, t, true)
+    val t1 = asTerm(ut1)
+    shouldBeAlphaEquiv(t1, t1)
+    shouldBeAlphaEquiv(t1, t1, true)
+
+    //Let's use polymorphic constants
+    val t2 = asTerm(ut2)
+    shouldBeAlphaEquiv(t2, t2)
+    shouldBeAlphaEquiv(t2, t2, true)
+
+    val t3 = asTerm(ut3)
+
+    shouldBeAlphaEquiv(t3, t3)
+    shouldBeAlphaEquiv(t3, t3, true)
+
+    //Fully monomorphic type, no call to asTerm is needed.
+    shouldBeAlphaEquiv(ut4, ut4)
+    shouldBeAlphaEquiv(ut4, ut4, true)
   }
 
   it should "identify identical terms with different types (when ignoring types)" in {
-    shouldBeAlphaEquiv('x ->: 'x, 'x ->: 'x, true)
+    // The implicit conversion doing inference is effectful. The resulting terms will have
+    // what are morally alpha-equivalent types (with different fresh variables),
+    // but since they don't contain quantifiers we can't detect that (unless
+    // we implicitly universally quantify type variables -- doing that
+    // implicitly is a bit of a hack, and not cleanly compatible with
+    // first-class polymorphism, even though Hindley-Milner languages do
+    // that and suffer the consequences.
+    shouldBeAlphaEquiv(idUt, idUt, true)
+    shouldBeAlphaEquiv(ut2, ut2, true)
+    //A different test
+    shouldBeAlphaEquiv(ut4, ut4, true)
   }
 
   it should "distinguish identical terms with different type variables" in {
-    shouldBeAlphaDiff('x ->: 'x, 'x ->: 'x)
+    shouldBeAlphaDiff(idUt, idUt)
+    shouldBeAlphaDiff(ut2, ut2)
   }
 
   it should "identify alpha-equivalent terms" in {


### PR DESCRIPTION
This fixes alpha-equivalence and uses it in BetaReduction to check whether the normalizer converged to a fixpoint.