### PR TITLE
Reimplement pretty-printing through Kiama

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ lazy val bigClients = project in file("bigClients") dependsOn (clients % "test->
 
 lazy val icfp2014 = project in file("icfp2014") dependsOn (ilc % "test->test;compile->test")
 
-scalaVersion in ThisBuild := "2.11.2"
+scalaVersion in ThisBuild := "2.11.4"
 
 scalacOptions in ThisBuild := Seq("-deprecation", "-feature", "-unchecked", "-Xlint")
 
@@ -41,6 +41,9 @@ libraryDependencies +=
 
 libraryDependencies +=
   "org.scalaz" %% "scalaz-core" % "7.0.6"
+
+libraryDependencies +=
+  "com.googlecode.kiama" %% "kiama" % "1.8.0"
 
 initialCommands in console in ThisBuild := """
 import ilc.examples._

--- a/clients/src/test/scala/ilc/examples/MapReduceSuite.scala
+++ b/clients/src/test/scala/ilc/examples/MapReduceSuite.scala
@@ -9,7 +9,7 @@ class MapReduceSuite
 extends FunSuite
    with Matchers
 {
-  object Lang extends MapReduce
+  object Lang extends MapReduce with feature.base.Pretty
   import Lang._
 
   case object K1 extends Type

--- a/clients/src/test/scala/ilc/examples/MapReduceSuite.scala
+++ b/clients/src/test/scala/ilc/examples/MapReduceSuite.scala
@@ -8,19 +8,15 @@ import org.scalatest.Matchers
 class MapReduceSuite
 extends FunSuite
    with Matchers
-   with MapReduce
 {
+  object Lang extends MapReduce
+  import Lang._
+
   case object K1 extends Type
   case object K2 extends Type
   case object V1 extends Type
   case object V2 extends Type
   case object V3 extends Type
-
-  // Matchers defines empty, bags.StdLib does too.
-  // Can't override with override val empty = super[MapReduce].empty because of
-  // https://issues.scala-lang.org/browse/SI-1938
-  // Luckily we don't actually need it here.
-  override val empty = null
 
   // TODO convert tests
   val mapPerKeyType =

--- a/clients/src/test/scala/longRunning/feature/abelianMaps/AbelianMapSuite.scala
+++ b/clients/src/test/scala/longRunning/feature/abelianMaps/AbelianMapSuite.scala
@@ -9,23 +9,24 @@ import ilc.feature.abelianMaps.Syntax
 import ilc.feature.abelianMaps.ToScala
 import ilc.util.EvalGenerated
 
-class AbelianMapSuite
-extends FunSuite
-   with Matchers
-   with EvalGenerated
-   with Syntax
-   with ToScala
-   with maps.SyntaxSugar // for map building method "fromAssoc"
-   with abelianGroups.Syntax
-   with abelianGroups.ToScala
-   with functions.SyntaxSugar
-   with functions.ToScala
-   with integers.ImplicitSyntaxSugar
-   with integers.ToScala
-   with naturals.Syntax
-   with naturals.ToScala
-   with maybe.ToScala
-{
+class AbelianMapSuite extends FunSuite with Matchers {
+  object Lang extends EvalGenerated
+    with Syntax
+    with ToScala
+    with maps.SyntaxSugar // for map building method "fromAssoc"
+    with abelianGroups.Syntax
+    with abelianGroups.ToScala
+    with functions.SyntaxSugar
+    with functions.ToScala
+    with integers.ImplicitSyntaxSugar
+    with integers.ToScala
+    with naturals.Syntax
+    with naturals.ToScala
+    with maybe.ToScala
+    with base.Pretty
+
+  import Lang._
+
   val myEmpty = EmptyMap(ℤ, ℤ)
   val singleton = SingletonMap ! 3 ! 5
   val _G_+ = additiveGroupOnIntegers

--- a/clients/src/test/scala/longRunning/feature/abelianMaps/DeltaAbelianMapSuite.scala
+++ b/clients/src/test/scala/longRunning/feature/abelianMaps/DeltaAbelianMapSuite.scala
@@ -10,23 +10,24 @@ import ilc.feature.abelianMaps.Library._
 import ilc.feature.abelianMaps.MapChanges
 import ilc.feature.abelianMaps.ToScala
 
-class DeltaAbelianMapSuite
-extends FunSuite
-   with Matchers
-   with AbelianDerivation
-   with integers.AbelianDerivation
-   with MapChanges
-   with functions.SyntaxSugar
-   with integers.SyntaxSugar
-   with maps.SyntaxSugar
-   with ToScala
-   with booleans.ToScala
-   with integers.ToScala
-   with functions.ToScala
-   with products.ToScala
-   with sums.ToScala
-   with EvalGenerated
-{
+class DeltaAbelianMapSuite extends FunSuite with Matchers {
+  object Lang extends AbelianDerivation
+    with integers.AbelianDerivation
+    with MapChanges
+    with functions.SyntaxSugar
+    with integers.SyntaxSugar
+    with maps.SyntaxSugar
+    with ToScala
+    with booleans.ToScala
+    with integers.ToScala
+    with functions.ToScala
+    with products.ToScala
+    with sums.ToScala
+    with EvalGenerated
+    with base.Pretty
+
+  import Lang._
+
   val additiveIntegerGroup = evalGenerated(additiveGroupOnIntegers).
     asInstanceOf[abelianGroups.Library.AbelianGroup[Int]]
 

--- a/icfp2014/src/main/scala/ilc/language/gcc/LambdaManApi.scala
+++ b/icfp2014/src/main/scala/ilc/language/gcc/LambdaManApi.scala
@@ -199,7 +199,7 @@ trait Collection extends SyntaxSugar { outer =>
     }("foldRightBody", 'go(list))
 
   def map(list: UT, f: UT) =
-    foldRight(list, empty, lam('head, 'tail) {
+    foldRight(list, emptyList, lam('head, 'tail) {
       f('head) ::: 'tail
     })
 
@@ -223,7 +223,7 @@ trait Collection extends SyntaxSugar { outer =>
       )("containsBody", 'go(list, el, comp))
 
     def filterNot(comp: UT /* T =>: bool */)
-      = foldRight(list, empty, lam('el, 'acc) {
+      = foldRight(list, emptyList, lam('el, 'acc) {
         if_(not(comp('el))) {
           'el ::: 'acc
         } else_ {
@@ -240,7 +240,7 @@ trait Collection extends SyntaxSugar { outer =>
         )("zipMain", 'go('list, 'other))*/
 
     def search(comp: UT /* T =>: bool */)
-      = foldRight(list, (empty, 0), lam('el, 'accPair) {
+      = foldRight(list, (emptyList, 0), lam('el, 'accPair) {
         'accPair.bind('acc, 'pos) {
           (if_(comp('el)) {
             ('el, 'pos) ::: 'acc
@@ -327,7 +327,7 @@ trait Collection extends SyntaxSugar { outer =>
 
       fun('toList)('_ % UnitType) {
         letrec (
-          'listResult := empty ofType ListType((KeyType, ValueType)),
+          'listResult := emptyList ofType ListType((KeyType, ValueType)),
 
           fun('toListHelper)('store) {
             if_('store.isEmptyTree) {
@@ -395,9 +395,9 @@ trait Pathfinding extends SyntaxSugar with Points with Collection { self: Lambda
         }
       )("extractPathGo",
         if_('parents.call('PointPointMap, 'isEmpty)(unit)) {
-          empty
+          emptyList
         } else_ {
-          'extractPathGo('to, empty).filterNot(lam('el){ 'pointEq('el, 'from) })
+          'extractPathGo('to, emptyList).filterNot(lam('el){ 'pointEq('el, 'from) })
         })
     },
 
@@ -524,7 +524,7 @@ trait Pathfinding extends SyntaxSugar with Points with Collection { self: Lambda
               }
             }
           }
-        }("pathfindingBody", 'loop('start, empty, 'start ::: empty, initWalked))
+        }("pathfindingBody", 'loop('start, emptyList, 'start ::: emptyList, initWalked))
       }
     }
   )
@@ -574,7 +574,7 @@ trait Points extends SyntaxSugar with Collection { outer: LambdaManApi =>
 
         'findColumn := lam('i, 'cols) {
           if_('cols.isEmpty) {
-            debug(1333) ~: empty
+            debug(1333) ~: emptyList
           }. else_if ('i === 'y) {
             'findCell(0, 'cols.head) ::: 'cols.tail
           } else_{
@@ -584,7 +584,7 @@ trait Points extends SyntaxSugar with Collection { outer: LambdaManApi =>
 
         'findCell := lam('j, 'cells) {
           if_('cells.isEmpty) {
-            debug(1334) ~: empty
+            debug(1334) ~: emptyList
           }. else_if ('j === 'x) {
             'value ::: 'cells.tail
           } else_{
@@ -604,7 +604,7 @@ trait Points extends SyntaxSugar with Collection { outer: LambdaManApi =>
   def createList(length: UT, init: UT): UT =
     letrec(
       'go := lam('n, 'init) {
-        if_('n === 0) { empty } else_ { 'init ::: 'go('n - 1, 'init) }
+        if_('n === 0) { emptyList } else_ { 'init ::: 'go('n - 1, 'init) }
       }
     )("createListBody", 'go(length, init))
 

--- a/icfp2014/src/main/scala/ilc/language/gcc/Program.scala
+++ b/icfp2014/src/main/scala/ilc/language/gcc/Program.scala
@@ -16,9 +16,9 @@ class ProgramBase extends GCC {
       move.left,    // current direction
       0,            // tick
       (0, 0),       // fruit position
-      empty,        // planned Path
+      emptyList,    // planned Path
       'collectCoins, // active strategy,
-      empty          // unvisited locations
+      emptyList      // unvisited locations
   ) ofType AIState
   lazy val stateSize = 6
 
@@ -86,7 +86,7 @@ class ProgramBase extends GCC {
             'pathValue := lam('path) { foldRight('path, 0, lam('pos, 'sum) { 'sum + 'valueOfPos('pos, 'map) }) },
 
             // find path with maximum value
-            'bestPath := foldRight('allPaths, (empty, -1), lam('path, 'pathAndOldVal) { 'pathAndOldVal.bind('oldPath, 'oldVal) {
+            'bestPath := foldRight('allPaths, (emptyList, -1), lam('path, 'pathAndOldVal) { 'pathAndOldVal.bind('oldPath, 'oldVal) {
               let('value, 'pathValue('path)) {
                 if_('value > 'oldVal) {
                   ('path, 'value)
@@ -119,7 +119,7 @@ class ProgramBase extends GCC {
       } ofType Strategy
       // pseudo-random move, depends on the tick
 //      fun('randomMove)('currentPos % Point, 'state % StrategyState, 'map % WorldMap) {
-//        ('mod('getTick('state), 4) ofType Dir) ::: empty
+//        ('mod('getTick('state), 4) ofType Dir) ::: emptyList
 //      }
   )
 
@@ -214,7 +214,7 @@ class ProgramBase extends GCC {
      * Collects all cells in the which could be used as targets
      */
     fun('collectunvisitedCells)('map % GameMap) {
-      foldRight('map, ('map.size - 1, empty), lam('row, 'acc1) { 'acc1.bind('i, 'cells) {
+      foldRight('map, ('map.size - 1, emptyList), lam('row, 'acc1) { 'acc1.bind('i, 'cells) {
         ('i - 1, foldRight('row, ('row.size - 1, 'cells), lam('cell, 'acc2) { 'acc2.bind('j, 'cells) {
           if_('cell === item.wall) { ('j - 1, 'cells) } else_ { ('j - 1, ('j, 'i) ::: 'cells) }
         }}).second)
@@ -257,7 +257,7 @@ class ProgramBase extends GCC {
           'xSize  := size('map.head),
 
           'unvisited := 'collectunvisitedCells('map)
-        ){ tuple('dir, 'tick, 'fruitPos, empty, 'collectCoins, 'unvisited)  }
+        ){ tuple('dir, 'tick, 'fruitPos, emptyList, 'collectCoins, 'unvisited)  }
     },
 
     // second component: The step function
@@ -269,7 +269,7 @@ class ProgramBase extends GCC {
         'state.bind('currDir % Dir, 'tick % int, 'fruitPos % Point, 'path % Path, 'strategy % Strategy, 'unvisited % ListType(Point)) {
           // something didn't work... Start over again
           if_('currDir === -1) {
-            'step(tuple('currDir, 'tick, 'fruitPos, empty, 'strategy, 'unvisited), 'world)
+            'step(tuple('currDir, 'tick, 'fruitPos, emptyList, 'strategy, 'unvisited), 'world)
           // Hey that's a ghost.. we need to evade
           //}. else_if () {
 

--- a/icfp2014/src/test/scala/ilc/language/gcc/CollectionsSuite.scala
+++ b/icfp2014/src/test/scala/ilc/language/gcc/CollectionsSuite.scala
@@ -6,12 +6,7 @@ import org.scalatest.FunSuite
 import org.scalatest.Matchers
 import GCC._
 
-class GCCCollectionsSuite
-extends FunSuite
-   with Matchers
-   with Evaluation
-{
-
+class GCCCollectionsSuite extends FunSuite with Matchers {
   def withLibraries(body: UT) =
      typecheck { letS((collectionApi ++ math ++ points):_*)(body) }
 

--- a/icfp2014/src/test/scala/ilc/language/gcc/PrimitivesSuite.scala
+++ b/icfp2014/src/test/scala/ilc/language/gcc/PrimitivesSuite.scala
@@ -8,11 +8,7 @@ import org.scalatest.Matchers
 import Predef.{any2stringadd => _, _}
 import scala.language.reflectiveCalls
 
-class GCCPrimitivesSuite
-extends FunSuite
-   with Matchers
-   with Evaluation
-{
+class GCCPrimitivesSuite extends FunSuite with Matchers {
   import GCC._
 
   test("Booleans") {

--- a/src/main/scala/ilc/feature/bags/Syntax.scala
+++ b/src/main/scala/ilc/feature/bags/Syntax.scala
@@ -58,7 +58,7 @@ extends Syntax
    with inference.PrettySyntax
 {
   //  empty     : Bag v
-  val empty: UntypedTerm = EmptyBag
+  val emptyBag: UntypedTerm = EmptyBag
 
   //  singleton : v → Bag v
   val singleton: UntypedTerm = Singleton

--- a/src/main/scala/ilc/feature/base/Pretty.scala
+++ b/src/main/scala/ilc/feature/base/Pretty.scala
@@ -16,6 +16,18 @@ package base
 
 import org.kiama.output
 
+
+/** Unary expressions with space beind */
+trait SpacedPrettyUnaryExpression extends output.PrettyUnaryExpression
+
+/** Juxtaposition */
+trait PrettyJuxtaposedExpression extends output.PrettyBinaryExpression {
+  def left : output.PrettyExpression
+  def right: output.PrettyExpression
+
+  override def op = ""
+}
+
 trait Pretty extends Syntax with PrettyPrinterInterfaceFromKiama {
   /** Things that are never parenthesized */
   case class PrettyNullaryExpression(toDoc: Doc)
@@ -24,9 +36,55 @@ trait Pretty extends Syntax with PrettyPrinterInterfaceFromKiama {
   /** `ParenPrettyPrinter.toParenDoc`
     * extended to handle PrettyNullaryExpression
     */
-  def toParenDoc(e: PrettyExpression): Doc = e match {
-    case PrettyNullaryExpression(doc) => doc
-    case _                            => ParenPrettyPrinter.toParenDoc(e)
+  override def toParenDoc(e: PrettyExpression): Doc = e match {
+    case PrettyNullaryExpression(doc) =>
+      doc
+
+    case u: SpacedPrettyUnaryExpression =>
+      import ParenPrettyPrinter.{bracket, group, indent, line}
+      val ed = u.exp match {
+        case e: output.PrettyOperatorExpression =>
+          val assoc = u.fixity match {
+            case Prefix  => RightAssoc
+            case Postfix => LeftAssoc
+          }
+          bracket(e, u, assoc)
+
+        case e =>
+          toParenDoc(e)
+      }
+      if (u.fixity == Prefix)
+        group(text(u.op) <> line <> indent(ed))
+      else
+        group(ed <> line <> indent(text(u.op)))
+
+    // override default implementation of binary operation
+    case b: output.PrettyBinaryExpression =>
+      import ParenPrettyPrinter.{bracket, group, indent, line}
+
+      val ld = b.left match {
+        case l: output.PrettyOperatorExpression =>
+          bracket(l, b, LeftAssoc)
+
+        case l =>
+          toParenDoc(l)
+      }
+
+      val rd = b.right match {
+        case r: output.PrettyOperatorExpression =>
+          bracket(r, b, RightAssoc)
+
+        case r =>
+          toParenDoc(r)
+      }
+
+      if (b.op.nonEmpty)
+        group(ld <+> text(b.op) <> line <> indent(rd))
+      else
+        group(ld <> line <> indent(rd))
+
+    case _ =>
+      super.toParenDoc(e)
   }
 
   /** @return org.kiama.output.PrettyExpression
@@ -52,11 +110,48 @@ trait Pretty extends Syntax with PrettyPrinterInterfaceFromKiama {
 
 trait PrettyPrinterInterfaceFromKiama {
   // we cannot inherit from ParenPrettyPrinter because its
-  // interface conflicts with scalatest.Matchers.
+  // interface conflicts with scalatest.Matchers. They both
+  // define `empty` of different types.
+  //
+  // using Ruby's aliasing pattern to restore dynamic dispatch
+  // so that `toParenDoc` stays an open method.
 
-  object ParenPrettyPrinter extends output.ParenPrettyPrinter
+  object ParenPrettyPrinter extends output.ParenPrettyPrinter {
+    override def toParenDoc(e: PrettyExpression): Doc =
+      PrettyPrinterInterfaceFromKiama.this.toParenDoc(e)
+
+    private[PrettyPrinterInterfaceFromKiama]
+    def defaultToParenDoc(e: PrettyExpression): Doc =
+      super.toParenDoc(e)
+
+    // make parenthesizing super simple
+    override def noparens(
+      inner: output.PrettyOperatorExpression,
+      outer: output.PrettyOperatorExpression,
+      side : output.Side):
+        Boolean =
+      if (matchingAssoc(outer.fixity, side))
+        inner.priority <= outer.priority
+      else
+        inner.priority <  outer.priority
+
+  def matchingAssoc(fixity: output.Fixity, side: output.Side): Boolean =
+    fixity match {
+      case Infix(LeftAssoc)  => side == LeftAssoc
+      case Infix(RightAssoc) => side == RightAssoc
+      case Prefix            => side == RightAssoc
+      case Postfix           => side == LeftAssoc
+      case _                 => false
+    }
+
+    // override defaults here:
+    override val defaultIndent = 2
+  }
 
   // aliases such that subclasses need not be aware of Kiama
+  type SpacedPrettyUnaryExpression = ilc.feature.base.SpacedPrettyUnaryExpression
+  type PrettyJuxtaposedExpression  = ilc.feature.base.PrettyJuxtaposedExpression
+
   import org.kiama.output
   trait PrettyUnaryExpression  extends output.PrettyUnaryExpression
   trait PrettyBinaryExpression extends output.PrettyBinaryExpression
@@ -75,4 +170,7 @@ trait PrettyPrinterInterfaceFromKiama {
 
   def text(s: String) = ParenPrettyPrinter.text(s)
   def defaultWidth    = ParenPrettyPrinter.defaultWidth
+
+  def toParenDoc(e: PrettyExpression): Doc =
+    ParenPrettyPrinter.defaultToParenDoc(e)
 }

--- a/src/main/scala/ilc/feature/base/Pretty.scala
+++ b/src/main/scala/ilc/feature/base/Pretty.scala
@@ -20,18 +20,6 @@
   * If a new term constructor's case is not overridden in
   * toPrettyExpression, then that constructor will be
   * printed by calling `prettyPrintDefault`.
-  *
-  * CAUTION: due to interface conflict between Kiama and
-  * Scalatest, trait Pretty cannot be a subclass of
-  * kiama.output.ParenPrettyPrinter. We have to delegate
-  * instead.
-  *
-  * Subclasses may import from ParenPrettyPrinter.
-  * However, directly imported methods won't perform
-  * dynamic dispatch. If dynamic dispatch/open method
-  * is desired, then one must define an alias in
-  * trait PrettyPrinterInterfaceFromKiama, similar to
-  * `bracket`, `line`, `nest` etc.
   */
 
 package ilc

--- a/src/main/scala/ilc/feature/base/Pretty.scala
+++ b/src/main/scala/ilc/feature/base/Pretty.scala
@@ -14,8 +14,8 @@
   *     to an operator with arity, fixity and precedence
   *
   * If a new term constructor's case is not overridden in
-  * operatorPrecedence, then future subclasses won't be
-  * able to look up that constructor's precedence.
+  * operatorPrecedence, then that constructor will be
+  * considered atomic and bind the tightest.
   *
   * If a new term constructor's case is not overridden in
   * toPrettyExpression, then that constructor will be

--- a/src/main/scala/ilc/feature/base/Pretty.scala
+++ b/src/main/scala/ilc/feature/base/Pretty.scala
@@ -7,7 +7,7 @@
   *
   * - operatorPrecedence, for terms and types:
   *     assign to each term constructor an integer
-  *     signifying how loosely the term constructor binds
+  *     signifying how tightly the term constructor binds
   *
   * - toPrettyExpresion, for terms and types:
   *     convert declared term constructors
@@ -61,12 +61,12 @@ trait Pretty extends Syntax with PrettyPrinterInterfaceFromKiama {
   }
 
   def operatorPrecedence(tau: Type): Int =
-    Int.MinValue // by default, do not parenthesize types
+    Int.MaxValue // by default, do not parenthesize types
 
   /** look up the operator precedence of a term */
   def operatorPrecedence(t: Term): Int = t match {
     case Var(_, _) =>
-      Int.MinValue // variables are never parenthesized
+      Int.MaxValue // variables are never parenthesized
   }
 
   /** @return org.kiama.output.PrettyExpression
@@ -185,9 +185,9 @@ trait PrettyPrinterInterfaceFromKiama {
       side : output.Side):
         Boolean =
       if (matchingAssoc(outer.fixity, side))
-        inner.priority <= outer.priority
+        inner.priority >= outer.priority
       else
-        inner.priority <  outer.priority
+        inner.priority >  outer.priority
 
   def matchingAssoc(fixity: output.Fixity, side: output.Side): Boolean =
     fixity match {

--- a/src/main/scala/ilc/feature/base/Pretty.scala
+++ b/src/main/scala/ilc/feature/base/Pretty.scala
@@ -36,7 +36,7 @@ trait Pretty extends ParenPrettyPrinter {
       * pretty-printed by default (if overrides of Pretty don't take
       * precedence). By default, this delegates to `toString`.
       */
-    def prettyPrintDefault = toString
+    def prettyPrintDefault: Doc = text(toString)
   }
 
   /** Juxtaposition */
@@ -143,7 +143,7 @@ trait PrettyTypes extends Pretty {
     * By default, render type `tau` by calling `tau.prettyPrintDefault`
     */
   def toPrettyExpression(tau: Type): PrettyExpression =
-    PrettyNullaryExpression(text(tau.prettyPrintDefault))
+    PrettyNullaryExpression(tau.prettyPrintDefault)
 
   def toDoc(t: Type): Doc =
     toParenDoc(toPrettyExpression(t))
@@ -175,7 +175,7 @@ trait PrettySyntax extends Pretty {
       PrettyNullaryExpression(text(name.toString))
 
     case unknownTerm =>
-      PrettyNullaryExpression(text(unknownTerm.prettyPrintDefault))
+      PrettyNullaryExpression(unknownTerm.prettyPrintDefault)
   }
 
   def toDoc(t: Term): Doc =

--- a/src/main/scala/ilc/feature/base/Pretty.scala
+++ b/src/main/scala/ilc/feature/base/Pretty.scala
@@ -62,9 +62,9 @@ trait Pretty extends Syntax with PrettyPrinterInterfaceFromKiama {
           toParenDoc(e)
       }
       if (u.fixity == Prefix)
-        group(u.op <> line <> nest(ed))
+        group(u.op <> nest(line <> ed))
       else
-        group(ed <> line <> nest(u.op))
+        group(ed <> nest(line <> u.op))
 
     // override default implementation of binary operation
     case b: output.PrettyBinaryExpression =>
@@ -85,9 +85,9 @@ trait Pretty extends Syntax with PrettyPrinterInterfaceFromKiama {
       }
 
       if (b.op.nonEmpty)
-        group(ld <+> text(b.op) <> line <> nest(rd))
+        group(ld <+> text(b.op) <> nest(line <> rd))
       else
-        group(ld <> line <> nest(rd))
+        group(ld <> nest(line <> rd))
 
     case _ =>
       super.toParenDoc(e)

--- a/src/main/scala/ilc/feature/base/Pretty.scala
+++ b/src/main/scala/ilc/feature/base/Pretty.scala
@@ -5,9 +5,21 @@
   *
   * Subclass are obligated to override:
   *
+  * - operatorPrecedence
+  *     assign to each term constructor an integer
+  *     signifying how loosely the term constructor binds
+  *
   * - toPrettyExpresion:
   *     convert declared term constructors
   *     to an operator with arity, fixity and precedence
+  *
+  * If a new term constructor's case is not overridden in
+  * operatorPrecedence, then future subclasses won't be
+  * able to look up that constructor's precedence.
+  *
+  * If a new term constructor's case is not overridden in
+  * toPrettyExpression, then that constructor will be
+  * printed by calling `toString`.
   */
 
 package ilc

--- a/src/main/scala/ilc/feature/base/Pretty.scala
+++ b/src/main/scala/ilc/feature/base/Pretty.scala
@@ -150,6 +150,16 @@ trait Pretty extends Syntax with PrettyPrinterInterfaceFromKiama {
 
   def pretty(t: Term, width: Width): Layout =
     ParenPrettyPrinter.pretty(toDoc(t), width)
+
+  def toDoc(t: Type): Doc =
+    toParenDoc(toPrettyExpression(t))
+
+  /** support pretty printing on terms */
+  def pretty(t: Type): Layout =
+    pretty(t, defaultWidth)
+
+  def pretty(t: Type, width: Width): Layout =
+    ParenPrettyPrinter.pretty(toDoc(t), width)
 }
 
 trait PrettyPrinterInterfaceFromKiama {

--- a/src/main/scala/ilc/feature/base/Pretty.scala
+++ b/src/main/scala/ilc/feature/base/Pretty.scala
@@ -41,6 +41,10 @@ package base
 import org.kiama.output
 import output._
 
+trait PrettyPrintable {
+  def prettyPrintDefault: String = toString
+}
+
 trait Pretty extends Syntax with ParenPrettyPrinter {
   /** Juxtaposition */
   trait PrettyJuxtaposedExpression extends PrettyBinaryExpression {
@@ -75,7 +79,7 @@ trait Pretty extends Syntax with ParenPrettyPrinter {
     * By default, render type `tau` by calling `tau.toString`
     */
   def toPrettyExpression(tau: Type): PrettyExpression =
-    PrettyNullaryExpression(text(tau.toString))
+    PrettyNullaryExpression(text(tau.prettyPrintDefault))
 
   /** @return org.kiama.output.PrettyExpression
     *         representing the given term
@@ -87,7 +91,7 @@ trait Pretty extends Syntax with ParenPrettyPrinter {
       PrettyNullaryExpression(text(name.toString))
 
     case unknownTerm =>
-      PrettyNullaryExpression(text(unknownTerm.toString))
+      PrettyNullaryExpression(text(unknownTerm.prettyPrintDefault))
   }
 
   /** `ParenPrettyPrinter.toParenDoc`

--- a/src/main/scala/ilc/feature/base/Pretty.scala
+++ b/src/main/scala/ilc/feature/base/Pretty.scala
@@ -1,0 +1,78 @@
+/** Pretty-printing infrastructure
+  *
+  * For each feature declaring a new Term constructor,
+  * it should extend this trait.
+  *
+  * Subclass are obligated to override:
+  *
+  * - toPrettyExpresion:
+  *     convert declared term constructors
+  *     to an operator with arity, fixity and precedence
+  */
+
+package ilc
+package feature
+package base
+
+import org.kiama.output
+
+trait Pretty extends Syntax with PrettyPrinterInterfaceFromKiama {
+  /** Things that are never parenthesized */
+  case class PrettyNullaryExpression(toDoc: Doc)
+      extends PrettyExpression
+
+  /** `ParenPrettyPrinter.toParenDoc`
+    * extended to handle PrettyNullaryExpression
+    */
+  def toParenDoc(e: PrettyExpression): Doc = e match {
+    case PrettyNullaryExpression(doc) => doc
+    case _                            => ParenPrettyPrinter.toParenDoc(e)
+  }
+
+  /** @return org.kiama.output.PrettyExpression
+    *         representing the given term
+    *
+    * By default, render term `t` by calling `t.toString`.
+    */
+  def toPrettyExpression(t: Term): PrettyExpression = t match {
+    case Var(name, tpe) =>
+      PrettyNullaryExpression(text(name.toString))
+
+    case unknownTerm =>
+      PrettyNullaryExpression(text(unknownTerm.toString))
+  }
+
+  /** support pretty printing on terms */
+  def pretty(t: Term): Layout =
+    pretty(t, defaultWidth)
+
+  def pretty(t: Term, width: Width): Layout =
+    ParenPrettyPrinter.pretty(toParenDoc(toPrettyExpression(t)), width)
+}
+
+trait PrettyPrinterInterfaceFromKiama {
+  // we cannot inherit from ParenPrettyPrinter because its
+  // interface conflicts with scalatest.Matchers.
+
+  object ParenPrettyPrinter extends output.ParenPrettyPrinter
+
+  // aliases such that subclasses need not be aware of Kiama
+  import org.kiama.output
+  trait PrettyUnaryExpression  extends output.PrettyUnaryExpression
+  trait PrettyBinaryExpression extends output.PrettyBinaryExpression
+
+  type PrettyExpression = output.PrettyExpression
+  val  LeftAssoc        = output.LeftAssoc
+  val  RightAssoc       = output.RightAssoc
+  val  NonAssoc         = output.NonAssoc
+  val  Prefix           = output.Prefix
+  val  Postfix          = output.Postfix
+  val  Infix            = output.Infix
+
+  type Doc    = ParenPrettyPrinter.Doc
+  type Width  = ParenPrettyPrinter.Width
+  type Layout = ParenPrettyPrinter.Layout
+
+  def text(s: String) = ParenPrettyPrinter.text(s)
+  def defaultWidth    = ParenPrettyPrinter.defaultWidth
+}

--- a/src/main/scala/ilc/feature/base/Syntax.scala
+++ b/src/main/scala/ilc/feature/base/Syntax.scala
@@ -13,7 +13,7 @@ extends TypeConstructors
     val getType: Type
   }
 
-  trait Term extends Typed {
+  trait Term extends Typed with PrettyPrintable {
     // forces early failure for object-level type checking
     if(getType == null) {
       val className = this.getClass.getName
@@ -235,9 +235,7 @@ Please do not declare getType as an abstract `val`.
   {
     def specialize(argumentTypes: Type*): Term = {
       case object Underscore extends Type {
-        override def toString = "_"
-        //XXX this changes prettyprinting and improves some error messages,
-        //but we shouldn't redefine prettyprinting for that.
+        override def prettyPrintDefault = "_"
       }
 
       if (argumentTypesMatch(argumentTypes, toTerm.getType))

--- a/src/main/scala/ilc/feature/base/Syntax.scala
+++ b/src/main/scala/ilc/feature/base/Syntax.scala
@@ -234,7 +234,7 @@ Please do not declare getType as an abstract `val`.
   extends PolymorphicTerm
   {
     def specialize(argumentTypes: Type*): Term = {
-      case object Underscore extends Type { override def toString = "_" }
+      case object Underscore extends Type
 
       if (argumentTypesMatch(argumentTypes, toTerm.getType))
         toTerm

--- a/src/main/scala/ilc/feature/base/Syntax.scala
+++ b/src/main/scala/ilc/feature/base/Syntax.scala
@@ -241,7 +241,7 @@ Please do not declare getType as an abstract `val`.
       else {
         val term = toTerm.toString
         val actual = toTerm.getType
-        val expected = argumentTypes.foldRight(Underscore: Type)(_ =>: _).toString
+        val expected = argumentTypes.foldRight(Underscore: Type)(_ =>: _)
 
         typeErrorWrongType(term, actual, expected)
       }

--- a/src/main/scala/ilc/feature/base/Syntax.scala
+++ b/src/main/scala/ilc/feature/base/Syntax.scala
@@ -234,14 +234,18 @@ Please do not declare getType as an abstract `val`.
   extends PolymorphicTerm
   {
     def specialize(argumentTypes: Type*): Term = {
-      case object Underscore extends Type
+      case object Underscore extends Type {
+        override def toString = "_"
+        //XXX this changes prettyprinting and improves some error messages,
+        //but we shouldn't redefine prettyprinting for that.
+      }
 
       if (argumentTypesMatch(argumentTypes, toTerm.getType))
         toTerm
       else {
         val term = toTerm.toString
         val actual = toTerm.getType
-        val expected = argumentTypes.foldRight(Underscore: Type)(_ =>: _)
+        val expected = argumentTypes.foldRight[Type](Underscore)(_ =>: _)
 
         typeErrorWrongType(term, actual, expected)
       }

--- a/src/main/scala/ilc/feature/base/Syntax.scala
+++ b/src/main/scala/ilc/feature/base/Syntax.scala
@@ -235,7 +235,7 @@ Please do not declare getType as an abstract `val`.
   {
     def specialize(argumentTypes: Type*): Term = {
       case object Underscore extends Type {
-        override def prettyPrintDefault = "_"
+        override def prettyPrintDefault = text("_")
       }
 
       if (argumentTypesMatch(argumentTypes, toTerm.getType))

--- a/src/main/scala/ilc/feature/base/Syntax.scala
+++ b/src/main/scala/ilc/feature/base/Syntax.scala
@@ -6,7 +6,7 @@ import scala.language.implicitConversions
 import scala.language.postfixOps
 
 trait Syntax
-extends TypeConstructors
+extends TypeConstructors with PrettySyntax
 {
   trait Typed {
     /** Returns type or fails horribly. */

--- a/src/main/scala/ilc/feature/base/Types.scala
+++ b/src/main/scala/ilc/feature/base/Types.scala
@@ -4,7 +4,7 @@ package base
 
 import ilc.feature.inference.Reflection
 
-trait Types {
+trait Types extends PrettyTypes {
   // We want subclasses of Type to be case classes.
   // If subclass is not a case class/case object, then they
   // fail to instantiate at compile time (a good thing) with
@@ -18,9 +18,6 @@ trait Types {
   }
 
   // ERROR THROWERS
-
-  def pretty(t: Type): String
-
   def typeErrorWrongType(term: String, actual: Type, expected: Type): Nothing =
     throw TypeError(s"$term has type ${pretty(actual)} but should have type ${pretty(expected)}")
 

--- a/src/main/scala/ilc/feature/base/Types.scala
+++ b/src/main/scala/ilc/feature/base/Types.scala
@@ -12,7 +12,7 @@ trait Types {
   //
   // In unification we use the product iterator to map over all fields and we expect those to be types themselves.
   // If we ever want non-type fields we need to adapt ilc.feature.inference.Inference.unification
-  trait Type extends Product {
+  trait Type extends Product with PrettyPrintable {
     def traverse(f: Type => Type): Type =
       this
   }

--- a/src/main/scala/ilc/feature/base/Types.scala
+++ b/src/main/scala/ilc/feature/base/Types.scala
@@ -19,8 +19,10 @@ trait Types {
 
   // ERROR THROWERS
 
-  def typeErrorWrongType(term: String, actual: Type, expected: String): Nothing =
-    throw TypeError(s"$term has type $actual but should have type $expected")
+  def pretty(t: Type): String
+
+  def typeErrorWrongType(term: String, actual: Type, expected: Type): Nothing =
+    throw TypeError(s"$term has type ${pretty(actual)} but should have type ${pretty(expected)}")
 
   def typeErrorNotTheSame(context: String, expected: Any, actual: Any) =
     throw TypeError(s"expected $expected instead of $actual in $context")

--- a/src/main/scala/ilc/feature/bintrees/Pretty.scala
+++ b/src/main/scala/ilc/feature/bintrees/Pretty.scala
@@ -1,0 +1,15 @@
+package ilc
+package feature
+package bintrees
+
+trait Pretty extends Syntax with base.Pretty {
+  override def toPrettyExpression(tau: Type): PrettyExpression = tau match {
+    case BinTreeType(elemType) =>
+      PrettyNullaryExpression {
+        text("<#") <+> toDoc(tau) <+> text("#>")
+      }
+
+    case _ =>
+      super.toPrettyExpression(tau)
+  }
+}

--- a/src/main/scala/ilc/feature/bintrees/Pretty.scala
+++ b/src/main/scala/ilc/feature/bintrees/Pretty.scala
@@ -2,6 +2,8 @@ package ilc
 package feature
 package bintrees
 
+import org.kiama.output._
+
 trait Pretty extends Syntax with base.Pretty {
   override def toPrettyExpression(tau: Type): PrettyExpression = tau match {
     case BinTreeType(elemType) =>

--- a/src/main/scala/ilc/feature/bintrees/Pretty.scala
+++ b/src/main/scala/ilc/feature/bintrees/Pretty.scala
@@ -6,7 +6,7 @@ trait Pretty extends Syntax with base.Pretty {
   override def toPrettyExpression(tau: Type): PrettyExpression = tau match {
     case BinTreeType(elemType) =>
       PrettyNullaryExpression {
-        text("<#") <+> toDoc(tau) <+> text("#>")
+        text("<#") <+> toDoc(elemType) <+> text("#>")
       }
 
     case _ =>

--- a/src/main/scala/ilc/feature/bintrees/Types.scala
+++ b/src/main/scala/ilc/feature/bintrees/Types.scala
@@ -6,7 +6,6 @@ import ilc.util.ExtractorTrait
 
 trait Types extends base.Types with ExtractorTrait {
   case class BinTreeType(elemType: Type) extends Type {
-    override def toString = s"<#, $elemType, #>"
     override def traverse(f: Type => Type): Type = copy(f(elemType))
   }
 }

--- a/src/main/scala/ilc/feature/functions/Pretty.scala
+++ b/src/main/scala/ilc/feature/functions/Pretty.scala
@@ -1,118 +1,46 @@
 package ilc
-package feature.functions
+package feature
+package functions
 
 /**
  * Pretty printing for first-class functions.
  */
 
-trait Pretty extends Syntax with util.IndentUtils {
-  //Local-only addition to IndentUtils
-  protected def closeParenNoIndent(delim: String) = { indentLess(); delim }
+import org.kiama.output._
 
-  /**
-   * Pretty print an expression according to a template.
-   *
-   * @param inner
-   *   priority of the language construct to be printed
-   * @param outer
-   *   priority of the context to be printed in
-   * @param text
-   *   by-name argument with content to print.
-   */
-  def template(inner : Priority, outer : Priority, text : => String) = {
-    if (bindsStronger(inner, outer))
-      text
-     else
-       s"(${deeper(text, 1)})"
-       //Alternative: have body on separate lines as the parens
-       //openParen("(") + indent() + text + closeParen(")")
+trait Pretty extends base.Pretty with Syntax {
+  override def operatorPrecedence(t: Term): Int = t match {
+    case Abs(_, _) =>
+      10 // looser than Haskell's default operator (9)
+
+    case App(_, _) =>
+      0  // tighter than every positive precedence
+
+    case _ =>
+      super.operatorPrecedence(t)
   }
 
-  override protected def showTerm(t: Term): String = pretty(t)
+  override def toPrettyExpression(t: Term): PrettyExpression = t match {
+    case Abs(Var(x, xType), body) =>
+      new PrettyEnclosingExpression {
+        def priority = operatorPrecedence(t)
+        def fixity   = Prefix
 
-  /**
-   * Print a closed term to human-readable syntax.
-   *
-   * @param t
-   *   the term to print
-   */
-  def pretty(t: Term): String = {
-    indentNoNl() + pretty(t, outermostPriority)
-  }
-
-  /**
-   * Print a term to human-readable syntax.
-   *
-   * @param t
-   *   the term to print
-   * @param priority
-   *   the priority of the context this term is printed in
-   */
-  def pretty(t : Term, priority : Priority) : String = t match {
-    case variable: Var =>
-      variable.getName.toString
+        def op       = text("λ") <> text(x.toString) <> text(".")
+        def exp      = toPrettyExpression(body)
+      }
 
     case App(operator, operand) =>
-      template(priorityOfApp, priority,
-        //Increase indentation and break line before each argument.
-        s"${pretty(operator, priorityOfApp + 1)}${deeper(s"$indent${pretty(operand, priorityOfApp)}")}")
+      new PrettyJuxtaposedExpression {
+        // application binds tighter than everything
+        def priority = operatorPrecedence(t)
+        def fixity   = Infix(LeftAssoc)
 
-    case Abs(variable, body) =>
-      //Break lines before the body.
-
-      //How much should the body be indented, for perfect visual alignment? That's tricky.
-      val isBodyNestedAbs = body match {
-        case Abs(_, _) => true
-        case _ => false
+        def left  = toPrettyExpression(operator)
+        def right = toPrettyExpression(operand)
       }
-      val increaseInnerIndent =
-        //Nested abstractions should align with the first one.
-        (if (isBodyNestedAbs) 0 else indentDiff)
 
-      template(priorityOfAbs, priority,
-        s"λ${variable.getName.toString}.${deeper(s"$indent${pretty(body, priorityOfAbs + 1)}", increaseInnerIndent)}")
-
-    // other operations would throw "unknown term" error here.
-    // the pretty printer defaults to calling `toString`.
     case _ =>
-      t.toString
+      super.toPrettyExpression(t)
   }
-
-  // parentheses handling
-  //
-  // - subterms of λ are not parenthesized
-  // - nested applications are not parenthesized
-  // - constants are not parenthesized
-  // - variables are not parenthesized
-  // - all other subterms are parenthesized
-
-  /**
-   * The priority of an operator or language construct, for
-   * deciding whether to add parentheses when pretty printing.
-   *
-   * Smaller numbers mean stronger binding. For example, the
-   * priority of multiplication should be a number less than
-   * the priority of addition.
-   */
-  type Priority = Int
-
-  /**
-   * Priority of application.
-   */
-  val priorityOfApp : Priority = 1
-
-  /**
-   * Priority of abstraction.
-   */
-  val priorityOfAbs : Priority = 2
-
-  /**
-   * Priority of the outermost context.
-   *
-   * This priority is used when a term occurs in a context
-   * that is not a term itself.
-   */
-  val outermostPriority : Priority = 3
-
-  private def bindsStronger(a: Priority, b: Priority): Boolean = a < b
 }

--- a/src/main/scala/ilc/feature/functions/Pretty.scala
+++ b/src/main/scala/ilc/feature/functions/Pretty.scala
@@ -9,6 +9,14 @@ package functions
 import org.kiama.output._
 
 trait Pretty extends base.Pretty with Syntax {
+  override def operatorPrecedence(tau: Type): Int = tau match {
+    case domain =>: range =>
+      5
+
+    case _ =>
+      super.operatorPrecedence(tau)
+  }
+
   override def operatorPrecedence(t: Term): Int = t match {
     case Abs(_, _) =>
       10 // looser than Haskell's default operator (9)
@@ -18,6 +26,22 @@ trait Pretty extends base.Pretty with Syntax {
 
     case _ =>
       super.operatorPrecedence(t)
+  }
+
+  override def toPrettyExpression(tau: Type): PrettyExpression = tau match {
+    case domain =>: range =>
+      new PrettyBinaryExpression {
+        def priority = operatorPrecedence(tau)
+        def fixity   = Infix(RightAssoc)
+
+        def left     = toPrettyExpression(domain)
+        def right    = toPrettyExpression(range)
+
+        def op       = UnicodeOutput.choose("→", "->")
+      }
+
+    case _ =>
+      super.toPrettyExpression(tau)
   }
 
   override def toPrettyExpression(t: Term): PrettyExpression = t match {

--- a/src/main/scala/ilc/feature/functions/Pretty.scala
+++ b/src/main/scala/ilc/feature/functions/Pretty.scala
@@ -12,6 +12,11 @@ trait Pretty extends base.Pretty with Syntax {
   override def operatorPrecedence(tau: Type): Int = tau match {
     case domain =>: range =>
       5
+      // like in ILC's Agda code base: Parametric.Syntax.Type:
+      // infixr 5 _⇒_
+      //
+      // Ref.
+      // http://www.informatik.uni-marburg.de/~pgiarrusso/ILC/AEC/agda/Parametric.Syntax.Type.html
 
     case _ =>
       super.operatorPrecedence(tau)
@@ -19,10 +24,10 @@ trait Pretty extends base.Pretty with Syntax {
 
   override def operatorPrecedence(t: Term): Int = t match {
     case Abs(_, _) =>
-      10 // looser than Haskell's default operator (9)
+      0 // looser than everything
 
     case App(_, _) =>
-      0  // tighter than every positive precedence
+      10 // tighter than Haskell's default operator precedence (9)
 
     case _ =>
       super.operatorPrecedence(t)

--- a/src/main/scala/ilc/feature/functions/Syntax.scala
+++ b/src/main/scala/ilc/feature/functions/Syntax.scala
@@ -63,7 +63,7 @@ trait Syntax extends base.Syntax {
   /** Specify the argument type without specifying a name.
     * Useful in higher-order arguments.
     * {{{
-    * val powerOfTwo = FoldNat ! 1 ! lambda(NatType) {x => Plus ! x ! x}
+    * val powerOfTwo: Term = FoldNat ! Nat(1) ! lambda(NatType) {x => PlusNat ! x ! x}
     * }}}
     */
   def lambda(argumentType: Type)

--- a/src/main/scala/ilc/feature/functions/Types.scala
+++ b/src/main/scala/ilc/feature/functions/Types.scala
@@ -13,13 +13,6 @@ trait Types extends base.Types {
    * to create the type of Church numerals for base type foo.
    */
   case class =>: (domain: Type, range: Type) extends Type {
-    override def toString: String = {
-      val arrow = UnicodeOutput.choose("→", "->")
-      domain match {
-        case _ =>: _ => s"($domain) $arrow $range"
-        case _ => s"$domain $arrow $range"
-      }
-    }
     override def traverse(f: Type => Type) = copy(f(domain), f(range))
   }
 

--- a/src/main/scala/ilc/feature/integers/Pretty.scala
+++ b/src/main/scala/ilc/feature/integers/Pretty.scala
@@ -2,6 +2,8 @@ package ilc
 package feature
 package integers
 
+import org.kiama.output._
+
 trait Pretty extends Syntax with base.Pretty {
   override def toPrettyExpression(tau: Type): PrettyExpression = tau match {
     case IntType =>

--- a/src/main/scala/ilc/feature/integers/Pretty.scala
+++ b/src/main/scala/ilc/feature/integers/Pretty.scala
@@ -1,0 +1,13 @@
+package ilc
+package feature
+package integers
+
+trait Pretty extends Syntax with base.Pretty {
+  override def toPrettyExpression(tau: Type): PrettyExpression = tau match {
+    case IntType =>
+      PrettyNullaryExpression(text(UnicodeOutput.choose("ℤ", "Z")))
+
+    case _ =>
+      super.toPrettyExpression(tau)
+  }
+}

--- a/src/main/scala/ilc/feature/integers/Types.scala
+++ b/src/main/scala/ilc/feature/integers/Types.scala
@@ -3,9 +3,7 @@ package feature
 package integers
 
 trait Types extends base.Types {
-  case object IntType extends Type {
-    override def toString = UnicodeOutput.choose("ℤ", "Z")
-  }
+  case object IntType extends Type
 
   val ℤ = IntType
 }

--- a/src/main/scala/ilc/feature/let/Pretty.scala
+++ b/src/main/scala/ilc/feature/let/Pretty.scala
@@ -2,11 +2,38 @@ package ilc
 package feature
 package let
 
+import org.kiama.output._
+
 trait Pretty extends functions.Pretty with Syntax {
-  override def pretty(t: Term, priority: Priority) = t match {
+  override def operatorPrecedence(t: Term): Int = t match {
     case Let(variable, exp, body) =>
-      template(priorityOfAbs, priority,
-               s"${variable.getName.toString} =${deeper(s"$indent${pretty(exp, outermostPriority)}")};${indent}${pretty(body, outermostPriority)}")
-    case _ => super.pretty(t, priority)
+      // let-expressions binds as loosely as lambda expressions
+      super.operatorPrecedence(Abs(variable, body))
+
+    case _ =>
+      super.operatorPrecedence(t)
   }
+
+  override def toPrettyExpression(t: Term): PrettyExpression =
+    t match {
+      case Let(x, xdef, body) =>
+        new PrettyEnclosingExpression {
+          def priority = operatorPrecedence(t)
+          def fixity   = Prefix
+
+          def op =
+            group(
+              text("let") <>
+                nest(line <>
+                  text(x.getName.toString) <+> text("=") <>
+                    nest(line <> toDoc(xdef))
+                ) <> line <>
+                text("in"))
+
+          def exp = toPrettyExpression(body)
+        }
+
+      case _ =>
+        super.toPrettyExpression(t)
+    }
 }

--- a/src/main/scala/ilc/feature/lists/Pretty.scala
+++ b/src/main/scala/ilc/feature/lists/Pretty.scala
@@ -6,7 +6,7 @@ trait Pretty extends Syntax with base.Pretty {
   override def toPrettyExpression(tau: Type): PrettyExpression = tau match {
     case ListType(elemType) =>
       PrettyNullaryExpression {
-        text("[") <> toDoc(tau) <> text("]")
+        text("[") <> toDoc(elemType) <> text("]")
       }
 
     case _ =>

--- a/src/main/scala/ilc/feature/lists/Pretty.scala
+++ b/src/main/scala/ilc/feature/lists/Pretty.scala
@@ -1,0 +1,15 @@
+package ilc
+package feature
+package lists
+
+trait Pretty extends Syntax with base.Pretty {
+  override def toPrettyExpression(tau: Type): PrettyExpression = tau match {
+    case ListType(elemType) =>
+      PrettyNullaryExpression {
+        text("[") <> toDoc(tau) <> text("]")
+      }
+
+    case _ =>
+      super.toPrettyExpression(tau)
+  }
+}

--- a/src/main/scala/ilc/feature/lists/Pretty.scala
+++ b/src/main/scala/ilc/feature/lists/Pretty.scala
@@ -2,6 +2,8 @@ package ilc
 package feature
 package lists
 
+import org.kiama.output._
+
 trait Pretty extends Syntax with base.Pretty {
   override def toPrettyExpression(tau: Type): PrettyExpression = tau match {
     case ListType(elemType) =>

--- a/src/main/scala/ilc/feature/lists/Syntax.scala
+++ b/src/main/scala/ilc/feature/lists/Syntax.scala
@@ -48,10 +48,10 @@ trait InferenceSyntaxSugar extends Syntax with inference.SyntaxSugar {
     def get(i: Int) = project(i, t)
   }
 
-  def empty = asUntyped(Empty)
+  def emptyList = asUntyped(Empty)
 
   def list(args: UntypedTerm*) =
-    args.foldRight(empty)(_ ::: _)
+    args.foldRight(emptyList)(_ ::: _)
 
   //i is 0-based.
   def project(i: Int, t: UntypedTerm): UntypedTerm =

--- a/src/main/scala/ilc/feature/lists/Types.scala
+++ b/src/main/scala/ilc/feature/lists/Types.scala
@@ -6,7 +6,6 @@ import ilc.util.ExtractorTrait
 
 trait Types extends base.Types with ExtractorTrait {
   case class ListType(elemType: Type) extends Type {
-    override def toString = s"[$elemType]"
     override def traverse(f: Type => Type): Type = copy(f(elemType))
   }
 }

--- a/src/main/scala/ilc/feature/naturals/Pretty.scala
+++ b/src/main/scala/ilc/feature/naturals/Pretty.scala
@@ -1,0 +1,13 @@
+package ilc
+package feature
+package naturals
+
+trait Pretty extends Syntax with base.Pretty {
+  override def toPrettyExpression(tau: Type): PrettyExpression = tau match {
+    case NatType =>
+      PrettyNullaryExpression(text(UnicodeOutput.choose("ℕ", "N")))
+
+    case _ =>
+      super.toPrettyExpression(tau)
+  }
+}

--- a/src/main/scala/ilc/feature/naturals/Pretty.scala
+++ b/src/main/scala/ilc/feature/naturals/Pretty.scala
@@ -2,6 +2,8 @@ package ilc
 package feature
 package naturals
 
+import org.kiama.output._
+
 trait Pretty extends Syntax with base.Pretty {
   override def toPrettyExpression(tau: Type): PrettyExpression = tau match {
     case NatType =>

--- a/src/main/scala/ilc/feature/naturals/Types.scala
+++ b/src/main/scala/ilc/feature/naturals/Types.scala
@@ -3,9 +3,7 @@ package feature
 package naturals
 
 trait Types extends base.Types {
-  case object NatType extends Type {
-    override def toString = UnicodeOutput.choose("ℕ", "N")
-  }
+  case object NatType extends Type
 
   val ℕ = NatType
 }

--- a/src/main/scala/ilc/feature/products/Pretty.scala
+++ b/src/main/scala/ilc/feature/products/Pretty.scala
@@ -1,0 +1,33 @@
+package ilc
+package feature
+package products
+
+/**
+ * Pretty printing for first-class functions.
+ */
+
+trait Pretty extends base.Pretty with Syntax {
+  override def operatorPrecedence(tau: Type): Int = tau match {
+    case ProductType(leftType, rightType) =>
+      7 // like * in Haskell
+
+    case _ =>
+      super.operatorPrecedence(tau)
+  }
+
+  override def toPrettyExpression(tau: Type): PrettyExpression = tau match {
+    case ProductType(leftType, rightType) =>
+      new PrettyBinaryExpression {
+        def priority = operatorPrecedence(tau)
+        def fixity   = Infix(LeftAssoc)
+
+        def left     = toPrettyExpression(leftType)
+        def right    = toPrettyExpression(rightType)
+
+        def op       = UnicodeOutput.choose("×", "*")
+      }
+
+    case _ =>
+      super.toPrettyExpression(tau)
+  }
+}

--- a/src/main/scala/ilc/feature/products/Pretty.scala
+++ b/src/main/scala/ilc/feature/products/Pretty.scala
@@ -2,6 +2,8 @@ package ilc
 package feature
 package products
 
+import org.kiama.output._
+
 trait Pretty extends base.Pretty with Syntax {
   override def operatorPrecedence(tau: Type): Int = tau match {
     case ProductType(leftType, rightType) =>

--- a/src/main/scala/ilc/feature/products/Pretty.scala
+++ b/src/main/scala/ilc/feature/products/Pretty.scala
@@ -2,10 +2,6 @@ package ilc
 package feature
 package products
 
-/**
- * Pretty printing for first-class functions.
- */
-
 trait Pretty extends base.Pretty with Syntax {
   override def operatorPrecedence(tau: Type): Int = tau match {
     case ProductType(leftType, rightType) =>

--- a/src/main/scala/ilc/feature/products/Types.scala
+++ b/src/main/scala/ilc/feature/products/Types.scala
@@ -6,7 +6,6 @@ import ilc.util.ExtractorTrait
 
 trait Types extends base.Types with ExtractorTrait {
   case class ProductType(leftType: Type, rightType: Type) extends Type {
-    override def toString = s"($leftType) x ($rightType)"
     override def traverse(f: Type => Type) = copy(f(leftType), f(rightType))
   }
 

--- a/src/main/scala/ilc/feature/sums/Pretty.scala
+++ b/src/main/scala/ilc/feature/sums/Pretty.scala
@@ -2,6 +2,8 @@ package ilc
 package feature
 package sums
 
+import org.kiama.output._
+
 trait Pretty extends base.Pretty with Syntax {
   override def operatorPrecedence(tau: Type): Int = tau match {
     case SumType(leftType, rightType) =>

--- a/src/main/scala/ilc/feature/sums/Pretty.scala
+++ b/src/main/scala/ilc/feature/sums/Pretty.scala
@@ -2,10 +2,6 @@ package ilc
 package feature
 package sums
 
-/**
- * Pretty printing for first-class functions.
- */
-
 trait Pretty extends base.Pretty with Syntax {
   override def operatorPrecedence(tau: Type): Int = tau match {
     case SumType(leftType, rightType) =>

--- a/src/main/scala/ilc/feature/sums/Pretty.scala
+++ b/src/main/scala/ilc/feature/sums/Pretty.scala
@@ -1,0 +1,33 @@
+package ilc
+package feature
+package sums
+
+/**
+ * Pretty printing for first-class functions.
+ */
+
+trait Pretty extends base.Pretty with Syntax {
+  override def operatorPrecedence(tau: Type): Int = tau match {
+    case SumType(leftType, rightType) =>
+      6 // like + in Haskell
+
+    case _ =>
+      super.operatorPrecedence(tau)
+  }
+
+  override def toPrettyExpression(tau: Type): PrettyExpression = tau match {
+    case SumType(leftType, rightType) =>
+      new PrettyBinaryExpression {
+        def priority = operatorPrecedence(tau)
+        def fixity   = Infix(LeftAssoc)
+
+        def left     = toPrettyExpression(leftType)
+        def right    = toPrettyExpression(rightType)
+
+        def op       = "+"
+      }
+
+    case _ =>
+      super.toPrettyExpression(tau)
+  }
+}

--- a/src/main/scala/ilc/feature/unit/Pretty.scala
+++ b/src/main/scala/ilc/feature/unit/Pretty.scala
@@ -2,6 +2,8 @@ package ilc
 package feature
 package unit
 
+import org.kiama.output._
+
 trait Pretty extends Syntax with base.Pretty {
   override def toPrettyExpression(tau: Type): PrettyExpression = tau match {
     case UnitType =>

--- a/src/main/scala/ilc/feature/unit/Pretty.scala
+++ b/src/main/scala/ilc/feature/unit/Pretty.scala
@@ -1,0 +1,13 @@
+package ilc
+package feature
+package unit
+
+trait Pretty extends Syntax with base.Pretty {
+  override def toPrettyExpression(tau: Type): PrettyExpression = tau match {
+    case UnitType =>
+      PrettyNullaryExpression(text(UnicodeOutput.choose("𝟙", "1")))
+
+    case _ =>
+      super.toPrettyExpression(tau)
+  }
+}

--- a/src/main/scala/ilc/feature/unit/Types.scala
+++ b/src/main/scala/ilc/feature/unit/Types.scala
@@ -3,7 +3,5 @@ package feature
 package unit
 
 trait Types extends base.Types {
-  case object UnitType extends Type {
-    override def toString = UnicodeOutput.choose("𝟙", "1")
-  }
+  case object UnitType extends Type
 }

--- a/src/main/scala/ilc/language/bacchus/Pretty.scala
+++ b/src/main/scala/ilc/language/bacchus/Pretty.scala
@@ -6,3 +6,7 @@ import feature._
 
 trait Pretty
 extends functions.Pretty
+   with integers.Pretty
+   with naturals.Pretty
+   with sums.Pretty
+   with products.Pretty

--- a/src/test/scala/ilc/feature/base/PrettySuite.scala
+++ b/src/test/scala/ilc/feature/base/PrettySuite.scala
@@ -1,0 +1,25 @@
+package ilc
+package feature
+package base
+
+import org.scalatest.FunSuite
+
+class PrettySuite
+extends FunSuite
+   with base.Pretty
+{
+  case object Unit extends Type
+
+  def prettyVar(name: String): Layout =
+    pretty(Var(LiteralName(name), Unit))
+
+  test("Variables should pretty-print to their names") {
+    assert(prettyVar("x") == "x")
+    assert(prettyVar("y") == "y")
+
+    // beware: names must end in a lower-case letter
+    val superLongName = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+
+    assert(prettyVar(superLongName) == superLongName)
+  }
+}

--- a/src/test/scala/ilc/feature/base/PrettySuite.scala
+++ b/src/test/scala/ilc/feature/base/PrettySuite.scala
@@ -6,6 +6,7 @@ import org.scalatest.FunSuite
 
 class PrettySuite
 extends FunSuite
+   with base.Syntax
    with base.Pretty
 {
   case object Unit extends Type

--- a/src/test/scala/ilc/feature/base/TermBuilderSuite.scala
+++ b/src/test/scala/ilc/feature/base/TermBuilderSuite.scala
@@ -8,6 +8,7 @@ class TermBuilderSuite
 extends FunSuite
    with base.Syntax
    with functions.Syntax // for term application operator !
+   with Pretty
 {
   case object Bot extends Type { override def toString = "⊥" }
   case object Top extends Type { override def toString = "⊤" }

--- a/src/test/scala/ilc/feature/base/TypeInversionTest.scala
+++ b/src/test/scala/ilc/feature/base/TypeInversionTest.scala
@@ -7,6 +7,7 @@ import org.scalatest.FunSuite
 class TypeInversionTest
 extends FunSuite
    with functions.Syntax // for application
+   with Pretty
 {
   case object Bot extends Type
   case class T1(inner: Type) extends Type

--- a/src/test/scala/ilc/feature/booleans/BooleanSuite.scala
+++ b/src/test/scala/ilc/feature/booleans/BooleanSuite.scala
@@ -15,6 +15,7 @@ extends FunSuite
    with functions.Derivation
    with functions.Evaluation
    with functions.ToScala
+   with base.Pretty
 {
   val booleans = Seq(False, True)
 

--- a/src/test/scala/ilc/feature/fixpoint/FixpointSuite.scala
+++ b/src/test/scala/ilc/feature/fixpoint/FixpointSuite.scala
@@ -8,10 +8,8 @@ import org.scalatest.Matchers
 import language.bacchus
 import util.EvalGenerated
 
-class FixpointSuite
-extends FunSuite
-    with Matchers
-    with bacchus.Syntax
+class FixpointSuite extends FunSuite with Matchers {
+  object Lang extends bacchus.Syntax
     with bacchus.Pretty
     with bacchus.ToScala
     with Syntax
@@ -20,7 +18,9 @@ extends FunSuite
     with integers.ImplicitSyntaxSugar
     with integers.ToScala
     with bacchus.BasicDerivation
-    with EvalGenerated {
+    with EvalGenerated
+  import Lang._
+
   def multBase(m: Int, n: Int): Int =
     if (n == 0)
       0

--- a/src/test/scala/ilc/feature/functions/PrettySuite.scala
+++ b/src/test/scala/ilc/feature/functions/PrettySuite.scala
@@ -5,13 +5,12 @@ package functions
 import org.scalatest.FunSuite
 import org.scalatest.Matchers
 
-class PrettySuite
-extends FunSuite
-   with Matchers
-   with Pretty
-{
-  // force line breaks in all possible positions
-  override def defaultWidth = 0
+class PrettySuite extends FunSuite with Matchers {
+  object Lang extends Pretty {
+    // force line breaks in all possible positions
+    override val defaultWidth = 0
+  }
+  import Lang._
 
   def showPrintout(s: String) = info("printout:\n" + s)
 

--- a/src/test/scala/ilc/feature/functions/PrettySuite.scala
+++ b/src/test/scala/ilc/feature/functions/PrettySuite.scala
@@ -10,32 +10,34 @@ extends FunSuite
    with Matchers
    with Pretty
 {
+  // force line breaks in all possible positions
+  override def defaultWidth = 0
+
+  def showPrintout(s: String) = info("printout:\n" + s)
+
   case object Bot extends Type
 
   val id = lambda("x") { x => x }
   val id3 = id ! id%(Bot =>: Bot) ! id%Bot
-
-  //Avoid extra indentation in output, to ease writing correct expected output.
-  override protected def initialIndentDepth = 0
 
   test("The identity function prints λx. x") {
     val printout = pretty(id%Bot)
     printout should be (
       """|λx.
          |  x""".stripMargin)
-    info(printout)
+    showPrintout(printout)
   }
 
   test("Left-associative application print without extra parentheses") {
     val printout = pretty(id3)
     printout should be (
       """|(λx.
-         |   x)
+         |  x)
          |  (λx.
-         |     x)
+         |    x)
          |  (λx.
-         |     x)""".stripMargin)
-    info(printout)
+         |    x)""".stripMargin)
+    showPrintout(printout)
   }
 
   test("Variables are disambiguated with indices.") {
@@ -45,10 +47,10 @@ extends FunSuite
     val printout = pretty(shadowed%(Bot, Bot, Bot, Bot))
     val expected =
        """|λx.
-          |λx_1.
-          |λx_2.
-          |λx_3.
-          |  x_1""".stripMargin
+          |  λx_1.
+          |    λx_2.
+          |      λx_3.
+          |        x_1""".stripMargin
     printout should be (expected)
   }
 }

--- a/src/test/scala/ilc/feature/inference/FeaturesSuite.scala
+++ b/src/test/scala/ilc/feature/inference/FeaturesSuite.scala
@@ -11,6 +11,7 @@ import poly._
 trait InferenceTestHelper
   extends Inference
   with PrettySyntax
+  with base.Pretty
 {
 
   def onTypes[T](transformer: Type => Type): T => T = {

--- a/src/test/scala/ilc/feature/inference/InferenceSuite.scala
+++ b/src/test/scala/ilc/feature/inference/InferenceSuite.scala
@@ -10,6 +10,7 @@ extends FlatSpec
    with LetSyntaxSugar
    with LetInference
    with LetRecInference
+   with base.Pretty
 
 // Stuff for testing old inference
 with InferenceTestHelper

--- a/src/test/scala/ilc/feature/inference/PrettySuite.scala
+++ b/src/test/scala/ilc/feature/inference/PrettySuite.scala
@@ -1,4 +1,6 @@
-package ilc.feature.inference
+package ilc
+package feature
+package inference
 
 import org.scalatest._
 import scala.language.implicitConversions
@@ -16,11 +18,12 @@ trait ClashingImplicitConversion {
 class PrettySuite
 extends FlatSpec
    with SyntaxSugar
-   with ilc.feature.maps.Syntax
-   with ilc.feature.integers.Syntax
-   with ilc.util.EvalScala
-   with ilc.feature.bags.StdLib
-   with ilc.feature.abelianMaps.Syntax
+   with maps.Syntax
+   with integers.Syntax
+   with bags.StdLib
+   with abelianMaps.Syntax
+   with util.EvalScala
+   with base.Pretty
 {
   "If a 3rd party implicit adding `apply` method to Symbols is in scope," ++
     " then it " should "fail to compile. Error messages:" in {

--- a/src/test/scala/ilc/feature/let/BetaReductionSuite.scala
+++ b/src/test/scala/ilc/feature/let/BetaReductionSuite.scala
@@ -83,8 +83,8 @@ extends FlatSpec
   val duplicating = lambda(Var("f", NatType =>: NatType), Var("expensive", NatType)) {
     case Seq(arg, expensive) => PlusNat ! (arg ! expensive) ! (arg ! expensive)
   } ! u ! (PlusNat ! 42 ! 84)
-  pretty(duplicating)
-  pretty(normalize(duplicating))
+  info("\n" + pretty(duplicating))
+  info("\n" + pretty(normalize(duplicating)))
   /*
   val t =
     lambda(Var("param", NatType)) { param =>

--- a/src/test/scala/ilc/feature/let/BetaReductionSuite.scala
+++ b/src/test/scala/ilc/feature/let/BetaReductionSuite.scala
@@ -6,10 +6,9 @@ import org.scalatest.Matchers
 import org.scalatest.FlatSpec
 import ilc.util.EvalGenerated
 
-class BetaReductionSuite
-extends FlatSpec
-   with Matchers
-   with BetaReduction with naturals.ImplicitSyntaxSugar with Pretty with ToScala with ProgramSize with naturals.ToScala with EvalGenerated {
+class BetaReductionSuite extends FlatSpec with Matchers {
+  object Lang extends BetaReduction with naturals.ImplicitSyntaxSugar with Pretty with ToScala with ProgramSize with naturals.ToScala with EvalGenerated
+  import Lang._
 
   val x = Var("x", NatType)
   val y = Var("y", NatType)

--- a/src/test/scala/ilc/feature/let/BetaReductionSuite.scala
+++ b/src/test/scala/ilc/feature/let/BetaReductionSuite.scala
@@ -7,7 +7,7 @@ import org.scalatest.FlatSpec
 import ilc.util.EvalGenerated
 
 class BetaReductionSuite extends FlatSpec with Matchers {
-  object Lang extends BetaReduction with naturals.ImplicitSyntaxSugar with Pretty with ToScala with ProgramSize with naturals.ToScala with EvalGenerated
+  object Lang extends BetaReduction with naturals.ImplicitSyntaxSugar with Pretty with ToScala with ProgramSize with naturals.ToScala with EvalGenerated with ShowTerms
   import Lang._
 
   val x = Var("x", NatType)
@@ -82,8 +82,8 @@ class BetaReductionSuite extends FlatSpec with Matchers {
   val duplicating = lambda(Var("f", NatType =>: NatType), Var("expensive", NatType)) {
     case Seq(arg, expensive) => PlusNat ! (arg ! expensive) ! (arg ! expensive)
   } ! u ! (PlusNat ! 42 ! 84)
-  info("\n" + pretty(duplicating))
-  info("\n" + pretty(normalize(duplicating)))
+  info(show(duplicating))
+  info(show(normalize(duplicating)))
   /*
   val t =
     lambda(Var("param", NatType)) { param =>

--- a/src/test/scala/ilc/feature/maybe/DeltaMaybeSuite.scala
+++ b/src/test/scala/ilc/feature/maybe/DeltaMaybeSuite.scala
@@ -12,6 +12,7 @@ extends FunSuite
    with integers.Evaluation
    with integers.ImplicitSyntaxSugar
    with sums.Evaluation
+   with base.Pretty
 {
   //XXX abstract more?
   val toNope = Inj2(deltaType(ℤ)) ! Nope(ℤ)

--- a/src/test/scala/ilc/feature/products/ProductToScalaSuite.scala
+++ b/src/test/scala/ilc/feature/products/ProductToScalaSuite.scala
@@ -7,15 +7,16 @@ import org.scalatest.Matchers
 import ilc.util.EvalScala
 
 class ProductToScalaSuite
-extends FunSuite
-   with Matchers
-   with ToScala
-   with integers.ToScala
-   with functions.ToScala
-   with EvalScala
-   with SyntaxSugar
-   with integers.ImplicitSyntaxSugar
-{
+extends FunSuite with Matchers {
+  object Lang extends ToScala
+      with integers.ToScala
+      with functions.ToScala
+      with EvalScala
+      with SyntaxSugar
+      with integers.ImplicitSyntaxSugar
+      with base.Pretty
+  import Lang._
+
   def run(t: Term): Any = evalScala(toScala(t))
 
   val quintuple: Term = tuple(5) ! 1 ! 2 ! 3 ! 4 ! 5

--- a/src/test/scala/ilc/feature/sums/DeltaSumSuite.scala
+++ b/src/test/scala/ilc/feature/sums/DeltaSumSuite.scala
@@ -11,6 +11,7 @@ extends FunSuite
    with integers.AbelianDerivation
    with integers.Evaluation
    with integers.ImplicitSyntaxSugar
+   with base.Pretty
 {
   implicit class SumTypeOps(sigma: Type) {
     def ⊎ (tau: Type): Type =

--- a/src/test/scala/ilc/howTo/GetConstraintsOutOfConstantsSuite.scala
+++ b/src/test/scala/ilc/howTo/GetConstraintsOutOfConstantsSuite.scala
@@ -6,3 +6,4 @@ import org.scalatest.FunSuite
 class GetConstraintsOutOfConstantsSuite
 extends FunSuite
    with GetConstraintsOutOfConstants
+   with feature.base.Pretty

--- a/src/test/scala/ilc/howTo/WriteLambdaTerms.scala
+++ b/src/test/scala/ilc/howTo/WriteLambdaTerms.scala
@@ -22,7 +22,7 @@ class WriteLambdaTerms extends FlatSpec with Matchers {
   // The object language of paper 63 is simply typed lambda calculus.
   // Syntax trees of the object language can always be constructed
   // if the 3 rules below are observed.
-  // 
+  //
   //
   // t ::= x                 x           // (Scala identifier)
   //     | t₁ t₂             t1 ! t2

--- a/src/test/scala/ilc/howTo/WriteLambdaTerms.scala
+++ b/src/test/scala/ilc/howTo/WriteLambdaTerms.scala
@@ -8,15 +8,15 @@ import org.scalatest._
   * in the presence of simple right-to-left type inference
   */
 
-class WriteLambdaTerms
-extends FlatSpec with Matchers
-   with functions.Pretty
-   with integers.Syntax
-   with products.Syntax
-   with bags.Syntax
-   with sums.Syntax
-   with maps.Types // maps included for illustration only
-{
+class WriteLambdaTerms extends FlatSpec with Matchers {
+  object Lang extends functions.Pretty
+    with integers.Syntax
+    with products.Syntax
+    with bags.Syntax
+    with sums.Syntax
+    with maps.Types // maps included for illustration only
+  import Lang._
+
   // SHORT GUIDE
 
   // The object language of paper 63 is simply typed lambda calculus.

--- a/src/test/scala/ilc/language/bacchus/BacchusBasicDerivationSuite.scala
+++ b/src/test/scala/ilc/language/bacchus/BacchusBasicDerivationSuite.scala
@@ -8,3 +8,4 @@ import ilc.feature._
 class BacchusBasicDerivationSuite
 extends DerivativeTests
    with BasicDerivation
+   with base.Pretty

--- a/src/test/scala/ilc/language/bacchus/BacchusPrettySuite.scala
+++ b/src/test/scala/ilc/language/bacchus/BacchusPrettySuite.scala
@@ -8,8 +8,10 @@ import org.scalatest.Matchers
 class BacchusPrettySuite
 extends FunSuite
    with Matchers
-   with Evaluation
 {
+  object Lang extends Evaluation with feature.base.Pretty
+  import Lang._
+
   test("values have short descriptions") {
     NatValue(9).toString should be("9")
     MapValue(1 -> 4).toString should be("Map(1 -> 4)")

--- a/src/test/scala/ilc/language/bacchus/BacchusToScalaSuite.scala
+++ b/src/test/scala/ilc/language/bacchus/BacchusToScalaSuite.scala
@@ -13,6 +13,7 @@ extends FunSuite
    with ToScala
    with Subjects
    with EvalScala
+   with feature.base.Pretty
 {
   def run(t: Term): Any = {
     val code = toScala(t)

--- a/src/test/scala/ilc/language/bacchus/ReificationSuite.scala
+++ b/src/test/scala/ilc/language/bacchus/ReificationSuite.scala
@@ -14,6 +14,7 @@ extends FunSuite
    with maps.Reification
    with maybe.Reification
    with sums.Reification
+   with base.Pretty
 {
   test("can reify natural numbers") {
     val n: Value = 42

--- a/src/test/scala/ilc/language/bacchus/TypeCheckingSuite.scala
+++ b/src/test/scala/ilc/language/bacchus/TypeCheckingSuite.scala
@@ -1,0 +1,18 @@
+package ilc
+package language
+package bacchus
+
+import feature._
+import org.scalatest.FunSuite
+import org.scalatest.Matchers
+
+class TypeCheckingSuite extends FunSuite with Matchers {
+  object Lang extends Bacchus
+  import Lang._
+
+  test("Base type inference gives accurate messages") {
+    intercept[base.TypeError] {
+      (FoldNat ! LiteralInt(1) ! lambda(NatType) { x => PlusInt ! x ! x }): Term
+    }.getMessage() should be ("Type error: PlusInt has type Z -> Z -> Z but should have type N -> N -> _")
+  }
+}

--- a/src/test/scala/ilc/language/testbed/FullPrettySuite.scala
+++ b/src/test/scala/ilc/language/testbed/FullPrettySuite.scala
@@ -1,0 +1,64 @@
+package ilc
+package language
+package testbed
+
+import feature._
+
+import org.scalatest.FunSuite
+
+class FullPrettySuite
+extends FunSuite
+
+   with bintrees.Pretty  // nullary
+   with integers.Pretty  // nullary
+   with lists.Pretty     // nullary
+   with naturals.Pretty  // nullary
+   with unit.Pretty      // nullary
+
+   with functions.Pretty // binary
+   with sums.Pretty      // binary
+   with products.Pretty  // binary
+{
+  // dummy types
+  case object A extends Type
+  case object B extends Type
+  case object C extends Type
+  case object D extends Type
+
+  val fun2 = (A =>: B) =>: (C =>: D)
+  val sum2 = SumType(SumType(A, B), SumType(C, D))
+  val pro2 = ProductType(ProductType(A, B), ProductType(C, D))
+
+  val funSum = A =>: SumType(B, C)
+  val funPro = A =>: ProductType(B, C)
+  val sumFun = SumType(A, B =>: C)
+  val sumPro = SumType(A, ProductType(B, C))
+  val proFun = ProductType(A, B =>: C)
+  val proSum = ProductType(A, SumType(B, C))
+
+  test("Should pretty-print nullary mixfix operators") {
+    assert(pretty(BinTreeType(BinTreeType(A))) == "<# <# A #> #>")
+    assert(pretty(ListType(BinTreeType(A)))    == "[<# A #>]")
+    assert(pretty(BinTreeType(ListType(A)))    == "<# [A] #>")
+    assert(pretty(ListType(ListType(A)))       == "[[A]]")
+
+    assert(pretty(IntType)  == "Z")
+    assert(pretty(NatType)  == "N")
+    assert(pretty(UnitType) == "1")
+  }
+
+  test("Pretty printer should respect associativity") {
+    assert(pretty(fun2) == "(A -> B) -> C -> D")
+    assert(pretty(sum2) == "A + B + (C + D)")
+    assert(pretty(pro2) == "A * B * (C * D)")
+  }
+
+  test("Pretty printer should respect precedence") {
+    assert(pretty(funSum) == "A -> B + C")
+    assert(pretty(funPro) == "A -> B * C")
+    assert(pretty(sumFun) == "A + (B -> C)")
+    assert(pretty(sumPro) == "A + B * C")
+    assert(pretty(proFun) == "A * (B -> C)")
+    assert(pretty(proSum) == "A * (B + C)")
+  }
+}

--- a/src/test/scala/ilc/metaprogs/AlphaEquivSpec.scala
+++ b/src/test/scala/ilc/metaprogs/AlphaEquivSpec.scala
@@ -10,9 +10,10 @@ class AlphaEquivSpec extends FlatSpec
     with inference.PrettySyntax with inference.LetSyntaxSugar
     with inference.LetInference
 
-    with ilc.feature.maps.Syntax
-    with ilc.feature.bags.StdLib
-    with ilc.feature.abelianMaps.Syntax
+    with feature.maps.Syntax
+    with feature.bags.StdLib
+    with feature.abelianMaps.Syntax
+    with base.Pretty
 
     with AlphaEquivLet {
   def shouldBeAlphaEquiv(t1: Term, t2: Term, ignoreTypes: Boolean = false) =


### PR DESCRIPTION
Fix #12.

* Use Kiama's pretty-printing library.

* Add pretty printer for types.

* Use Kiama's pretty printer for terms.

Please review for style adherence, sufficient testing and obvious bugs.