### PR TITLE
Hand written examples of incrementalization via memoization 

### DIFF
--- a/src/main/scala/ilc/feature/bags/Library.scala
+++ b/src/main/scala/ilc/feature/bags/Library.scala
@@ -13,9 +13,7 @@ object Library extends base.Library {
   object Bag {
     def apply[T](elements: T*) =
       elements.foldRight(bagEmpty[T]) { (element, bag) =>
-        bag.get(element).fold(bag.updated(element, 1)) { i =>
-          bag.updated(element, i + 1)
-        }
+        bag.updated(element, 1 + bag.get(element).fold(0) { i => i })
       }
   }
 

--- a/src/main/scala/ilc/feature/bags/Library.scala
+++ b/src/main/scala/ilc/feature/bags/Library.scala
@@ -35,6 +35,8 @@ class LibraryHelper {
         collisionHandler(otherwise)
     } -- toDelete
   }
+  def bagSingletonInt[T](t: T): Bag[T] =
+    HashMap(t -> 1)
 }
 
 object Library extends LibraryHelper with base.Library {
@@ -49,7 +51,8 @@ object Library extends LibraryHelper with base.Library {
 
   def bagEmpty[T]: Bag[T] = HashMap.empty[T, Int]
 
-  def bagSingleton[T]: (=>T) => Bag[T] = t => HashMap(t -> 1)
+  def bagSingleton[T]: (=>T) => Bag[T] =
+    t => bagSingletonInt(t)
 
   //This function only maps between calling conventions.
   def bagUnion[T]:

--- a/src/main/scala/ilc/feature/bags/Library.scala
+++ b/src/main/scala/ilc/feature/bags/Library.scala
@@ -7,28 +7,10 @@ import collection.mutable.Stack
 
 class LibraryHelper {
   type Bag[T] = HashMap[T, Int]
-}
-
-object Library extends LibraryHelper with base.Library {
-  import abelianGroups.Library._
-
-  object Bag {
-    def apply[T](elements: T*) =
-      elements.foldRight(bagEmpty[T]) { (element, bag) =>
-        bag.updated(element, 1 + bag.get(element).fold(0) { i => i })
-      }
-  }
-
-  def bagEmpty[T]: Bag[T] = HashMap.empty[T, Int]
-
-  def bagSingleton[T]: (=>T) => Bag[T] = t => HashMap(t -> 1)
 
   //XXX: Could be made much faster by using builders (avoiding immutable
   //copies), but this shouldn't be necessary.
-  def bagUnion[T]:
-      (=>Bag[T]) => (=>Bag[T]) => Bag[T] = b1Param => b2Param => {
-    lazy val b1 = b1Param
-    lazy val b2 = b2Param
+  def bagUnionInt[T](b1: Bag[T], b2: Bag[T]): Bag[T] = {
     val toDelete = Stack.empty[T]
     val collisionHandler: (((T, Int), (T, Int))) => (T, Int) = {
       case ((el1, count1), (el2, count2)) =>
@@ -52,6 +34,29 @@ object Library extends LibraryHelper with base.Library {
       case otherwise =>
         collisionHandler(otherwise)
     } -- toDelete
+  }
+}
+
+object Library extends LibraryHelper with base.Library {
+  import abelianGroups.Library._
+
+  object Bag {
+    def apply[T](elements: T*) =
+      elements.foldRight(bagEmpty[T]) { (element, bag) =>
+        bag.updated(element, 1 + bag.get(element).fold(0) { i => i })
+      }
+  }
+
+  def bagEmpty[T]: Bag[T] = HashMap.empty[T, Int]
+
+  def bagSingleton[T]: (=>T) => Bag[T] = t => HashMap(t -> 1)
+
+  //This function only maps between calling conventions.
+  def bagUnion[T]:
+      (=>Bag[T]) => (=>Bag[T]) => Bag[T] = b1Param => b2Param => {
+    lazy val b1 = b1Param
+    lazy val b2 = b2Param
+    bagUnionInt(b1, b2)
   }
 
   def bagFoldGroup[G, T]:

--- a/src/main/scala/ilc/feature/bags/Library.scala
+++ b/src/main/scala/ilc/feature/bags/Library.scala
@@ -5,10 +5,12 @@ package bags
 import collection.immutable.HashMap
 import collection.mutable.Stack
 
-object Library extends base.Library {
-  import abelianGroups.Library._
-
+class LibraryHelper {
   type Bag[T] = HashMap[T, Int]
+}
+
+object Library extends LibraryHelper with base.Library {
+  import abelianGroups.Library._
 
   object Bag {
     def apply[T](elements: T*) =

--- a/src/test/scala/ilc/examples/handwritten/NestedLoop1.scala
+++ b/src/test/scala/ilc/examples/handwritten/NestedLoop1.scala
@@ -3,26 +3,27 @@ package examples
 package handwritten
 
 import feature.bags.Library._
+import org.scalameter.api._
 
-class NestedLoop1 {
-  val N = 0
+class NestedLoop1 extends Serializable {
+  val N = 10
   val coll1Init = List[Int](0 to N - 1: _*)
   val coll2Init = List[Int](1 to N: _*)
 
   //On lists first. Bag[T] is a Map[T, Int], so it's less clear how to write this on maps.
-  def nestedLoop1(coll1: List[Int], coll2: List[Int]) : List[Int] =
+  def nestedLoop1(coll1: List[Int], coll2: List[Int]): List[Int] =
     for {
       i <- coll1
       j <- coll2
     } yield (i * N + j)
 
-  def nestedLoop2(coll1: List[Int], coll2: List[Int]) : List[Int] = {
+  def nestedLoop2(coll1: List[Int], coll2: List[Int]): List[Int] = {
     val g = (i: Int) => (j: Int) => i * N + j
     val f = (i: Int) => coll2.map(g(i))
     coll1.flatMap(f)
   }
 
-  def nestedLoop3(coll1: List[Int], coll2: List[Int]) : List[Int] = {
+  def nestedLoop3(coll1: List[Int], coll2: List[Int]): List[Int] = {
     val g = (i: Int) => (j: Int) => i * N + j
     val f = (i: Int) => coll2.map(g(i))
     coll1.map(f).flatten
@@ -34,6 +35,8 @@ class NestedLoop1Bench extends BaseBenchmark {
   import n._
 
   performance of "nestedLoop1" in {
-    nestedLoop1(coll1Init, coll2Init)
+    using(Gen.unit("dummy")) config testConfig in { _ =>
+      nestedLoop1(coll1Init, coll2Init)
+    }
   }
 }

--- a/src/test/scala/ilc/examples/handwritten/NestedLoop1.scala
+++ b/src/test/scala/ilc/examples/handwritten/NestedLoop1.scala
@@ -91,19 +91,14 @@ class NestedLoop1 extends Serializable {
 
 class MyBenchmarkingSetup extends BaseBenchmark {
   override def reporters = Seq(LoggingReporter())
-  override def buildExecutor = separateExecutor
-  //To make tests fast and have lots of memory
+  //Config. for real measurements.
+  //def myBenchConfig = testConfig
+  //To make tests fast, while still having lots of memory
   def myBenchConfig =
     Context(
       //reports.regression.significance -> 0.01, //Confidence level = 99 %
-      exec.jvmflags -> s"-Xmx${memorySizeMB}m -Xms${memorySizeMB}m -XX:CompileThreshold=100",
-      exec.minWarmupRuns -> 1,
-      exec.maxWarmupRuns -> 1,
-      exec.warmupCovThreshold -> 1.0,
-      exec.benchRuns -> 1,
-      exec.independentSamples -> 1,
-      exec.reinstantiation.fullGC -> false,
-      verbose -> false)
+      exec.jvmflags -> s"-Xmx${memorySizeMB}m -Xms${memorySizeMB}m -XX:CompileThreshold=100"
+    ) ++ verificationConfig
 }
 
 

--- a/src/test/scala/ilc/examples/handwritten/NestedLoop1.scala
+++ b/src/test/scala/ilc/examples/handwritten/NestedLoop1.scala
@@ -2,11 +2,15 @@ package ilc
 package examples
 package handwritten
 
+
+import util._
 import feature.bags.Library._
+
+import collection.{mutable, immutable}
 import org.scalameter.api._
 
 class NestedLoop1 extends Serializable {
-  val N = 10
+  val N = 1000
   val coll1Init = List[Int](0 to N - 1: _*)
   val coll2Init = List[Int](1 to N: _*)
 
@@ -28,15 +32,111 @@ class NestedLoop1 extends Serializable {
     val f = (i: Int) => coll2.map(g(i))
     coll1.map(f).flatten
   }
+
+  def getIdentityMap[Key, Value]: mutable.Map[Key, Value] = {
+    import java.util.IdentityHashMap
+    import scala.collection.JavaConverters._
+    new IdentityHashMap[Key, Value]().asScala
+  }
+
+  def memoedF[I, O](cache: mutable.Map[I, O])(f: I => O): I => O =
+    x => cache.getOrElseUpdate(x, f(x))
+
+  def memo[A, B](f: A => B): A => B = {
+    val cache = getIdentityMap[A, B]
+    memoedF(cache)(f)
+  }
+
+  //Also return the cache.
+  def nestedLoop3Memo(coll1: List[Int], coll2: List[Int]) /*: (List[Int], Any)*/ = {
+    val g = (i: Int) => (j: Int) => i * N + j
+    val f = (i: Int) => coll2.map(g(i))
+    //memo(coll1 => coll1.map(f))(coll1).flatten
+    //coll1.map(memoInt(f)).flatten
+    val cache = getIdentityMap[Int, List[Int]]
+    val ret = (coll1.map(x => cache.getOrElseUpdate(x, f(x))).flatten, cache)
+
+    Util.assertType[List[Int]](ret._1)
+    ret
+  }
+
+  /*
+   * This code kind-of implements what I described in
+   * https://github.com/Blaisorblade/ilc-ldiff/issues/14#issuecomment-99446136
+   * Some mismatches:
+   * - it doesn't use derivatives for f, since they aren't easily available here; I only use recomputation.
+   * - Updating the output collection is too slow with this representation.
+   *   But should I really update the collection?
+   *   For now, setting `getRightResult = false` skips building the updated result, and just computes the pieces for benchmarking purposes.
+   *
+   * Other notes:
+   * - This uses as collections List[Int] and ignores the order of elements. I should instead take Bag[Int], I guess.
+   */
+
+  def nestedLoop3Incr(coll1: List[Int], coll2: List[Int])(oldOut: List[Int], cache: mutable.Map[Int, List[Int]])(removedFromColl1: Int, addedToCol1: Int, getRightResult: Boolean): Any /*List[Int]*/ = {
+    val g = (i: Int) => (j: Int) => i * N + j
+    val f = (i: Int) => coll2.map(g(i))
+
+    val toDrop = cache.get(removedFromColl1)
+    val toAdd = //Correct result, but too slow with these data structures.
+      memoedF(cache)(f)(addedToCol1)
+
+    if (getRightResult)
+      oldOut.filterNot(toDrop.contains) ++ toAdd
+    else
+      //The result here is *not* good. But at least, return all pieces, to prevent optimizations from getting in the way of microbenchmarking.
+      (toAdd, toDrop)
+  }
 }
 
 class NestedLoop1Bench extends BaseBenchmark {
   val n = new NestedLoop1()
   import n._
+  val (res1, res1Cache) = nestedLoop3Memo(coll1Init, coll2Init)
+
+  override def reporters = Seq(LoggingReporter())
+  override def buildExecutor = separateExecutor
+  //To make tests fast and have lots of memory
+  def myConfig =
+    Context(
+      //reports.regression.significance -> 0.01, //Confidence level = 99 %
+      exec.jvmflags -> s"-Xmx${memorySizeMB}m -Xms${memorySizeMB}m -XX:CompileThreshold=100",
+      exec.minWarmupRuns -> 1,
+      exec.maxWarmupRuns -> 1,
+      exec.warmupCovThreshold -> 1.0,
+      exec.benchRuns -> 1,
+      exec.independentSamples -> 1,
+      exec.reinstantiation.fullGC -> false,
+      verbose -> false)
 
   performance of "nestedLoop1" in {
-    using(Gen.unit("dummy")) config testConfig in { _ =>
+    using(Gen.unit("dummy")) config myConfig in { _ =>
       nestedLoop1(coll1Init, coll2Init)
+    }
+  }
+
+  performance of "nestedLoop3" in {
+    using(Gen.unit("dummy")) config myConfig in { _ =>
+      nestedLoop3(coll1Init, coll2Init)
+    }
+  }
+
+  performance of "nestedLoop3Memo" in {
+    using(Gen.unit("dummy")) config myConfig in { _ =>
+      nestedLoop3Memo(coll1Init, coll2Init)
+    }
+  }
+
+  performance of "nestedLoop3Incr" in {
+    using(Gen.unit("dummy")) config myConfig in { _ =>
+      nestedLoop3Incr(coll1Init, coll2Init)(res1, res1Cache)(0, N, true)
+    }
+  }
+
+  //Cheat a lot, to get closer to the performance we'd hope with proper data structures.
+  performance of "nestedLoop3IncrSimulated" in {
+    using(Gen.unit("dummy")) config myConfig in { _ =>
+      nestedLoop3Incr(coll1Init, coll2Init)(res1, res1Cache)(0, N, false)
     }
   }
 }

--- a/src/test/scala/ilc/examples/handwritten/NestedLoop1.scala
+++ b/src/test/scala/ilc/examples/handwritten/NestedLoop1.scala
@@ -16,16 +16,20 @@ class Bag[A](private val contents: immutable.Map[A, Int] = immutable.HashMap()) 
 
   private def mapCommon[B](f: A => B) = {
      for {
-      (el, count) <- contents.toSeq
+      (el, count) <- contents.toSeq //.toSeq is just to change the result type. Alternatively, just use breakOut.
     } yield (f(el), count)
   }
 
+  /**
+   * Maps f over the bag content.
+   * Precondition: f is injective. Otherwise, resort to map.
+   */
   def mapInjective[B](f: A => B): Bag[B] = {
     new Bag(mapCommon(f).toMap)
   }
 
   /**
-   * This implements the expected map interface.
+   * This implements the expected map interface, sufficient for for-comprehension (though not CanBuildFrom-compliant).
    * By far not the most efficient implementation possible.
    * Untested.
    */
@@ -33,7 +37,7 @@ class Bag[A](private val contents: immutable.Map[A, Int] = immutable.HashMap()) 
     val internalMap = mapCommon(f).
       //F might not be injective
       map { case (el, count) => immutable.HashMap((el, count)) }.
-      fold(immutable.HashMap())(BagLib.bagUnionInt[B] _)
+      fold(BagLib.bagEmpty[B])(BagLib.bagUnionInt _)
     new Bag(internalMap)
   }
 }

--- a/src/test/scala/ilc/examples/handwritten/NestedLoop1.scala
+++ b/src/test/scala/ilc/examples/handwritten/NestedLoop1.scala
@@ -89,7 +89,7 @@ class NestedLoop1 extends Serializable {
   }
 }
 
-class MyBenchmarkingSetup extends BaseBenchmark {
+trait MyBenchmarkingSetup extends BaseBenchmark {
   override def reporters = Seq(LoggingReporter())
   //Config. for real measurements.
   //def myBenchConfig = testConfig

--- a/src/test/scala/ilc/examples/handwritten/NestedLoop1.scala
+++ b/src/test/scala/ilc/examples/handwritten/NestedLoop1.scala
@@ -50,6 +50,8 @@ class NestedLoop1 extends Serializable {
       j <- coll2
     } yield (i * N + j)
 
+  //def nestedLoopBags1(coll1: Bag[Int], coll2: Bag[Int])
+
   def nestedLoop2(coll1: List[Int], coll2: List[Int]): List[Int] = {
     val g = (i: Int) => (j: Int) => i * N + j
     val f = (i: Int) => coll2.map(g(i))

--- a/src/test/scala/ilc/examples/handwritten/NestedLoop1.scala
+++ b/src/test/scala/ilc/examples/handwritten/NestedLoop1.scala
@@ -11,7 +11,7 @@ import org.scalameter.api._
  * Warning: does not implement any actual collection interface.
  * I still aim for this to support for-comprehensions.
  */
-case class Bag[A](private val contents: immutable.Map[A, Int] = immutable.HashMap()) {
+case class Bag[A](contents: immutable.Map[A, Int] = immutable.HashMap()) {
   import feature.bags.{Library => BagLib}
 
   private def mapCommon[B](f: A => B) = {
@@ -89,8 +89,7 @@ object Bag {
     new Bag(t.map(BagLib.bagSingletonInt).fold(BagLib.bagEmpty)(BagLib.bagUnionInt _))
 }
 
-class NestedLoop1 extends Serializable {
-  val N = 1000
+class NestedLoop1(val N: Int = 1000) extends Serializable {
   val coll1Init = List[Int](0 to N - 1: _*)
   val coll2Init = List[Int](1 to N: _*)
   val coll1Upd = coll2Init
@@ -295,7 +294,7 @@ class NestedLoop1Bench extends MyBenchmarkingSetup {
 
 import org.scalatest._
 class NestedLoop1Test extends FlatSpec {
-  val n = new NestedLoop1()
+  val n = new NestedLoop1(3)
   import n._
 
   "nestedLoop1" should "be equivalent to nestedLoop3 and incremental variants" in {

--- a/src/test/scala/ilc/examples/handwritten/NestedLoop1.scala
+++ b/src/test/scala/ilc/examples/handwritten/NestedLoop1.scala
@@ -4,10 +4,39 @@ package handwritten
 
 
 import util._
-import feature.bags.Library._
-
 import collection.{mutable, immutable}
 import org.scalameter.api._
+
+/*
+ * Warning: does not implement any actual collection interface.
+ * I still aim for this to support for-comprehensions.
+ */
+class Bag[A](private val contents: immutable.Map[A, Int] = immutable.HashMap()) {
+  import feature.bags.{Library => BagLib}
+
+  private def mapCommon[B](f: A => B) = {
+     for {
+      (el, count) <- contents.toSeq
+    } yield (f(el), count)
+  }
+
+  def mapInjective[B](f: A => B): Bag[B] = {
+    new Bag(mapCommon(f).toMap)
+  }
+
+  /**
+   * This implements the expected map interface.
+   * By far not the most efficient implementation possible.
+   * Untested.
+   */
+  def map[B](f: A => B): Bag[B] = {
+    val internalMap = mapCommon(f).
+      //F might not be injective
+      map { case (el, count) => immutable.HashMap((el, count)) }.
+      fold(immutable.HashMap())(BagLib.bagUnionInt[B] _)
+    new Bag(internalMap)
+  }
+}
 
 class NestedLoop1 extends Serializable {
   val N = 1000

--- a/src/test/scala/ilc/examples/handwritten/NestedLoop1.scala
+++ b/src/test/scala/ilc/examples/handwritten/NestedLoop1.scala
@@ -1,0 +1,39 @@
+package ilc
+package examples
+package handwritten
+
+import feature.bags.Library._
+
+class NestedLoop1 {
+  val N = 0
+  val coll1Init = List[Int](0 to N - 1: _*)
+  val coll2Init = List[Int](1 to N: _*)
+
+  //On lists first. Bag[T] is a Map[T, Int], so it's less clear how to write this on maps.
+  def nestedLoop1(coll1: List[Int], coll2: List[Int]) : List[Int] =
+    for {
+      i <- coll1
+      j <- coll2
+    } yield (i * N + j)
+
+  def nestedLoop2(coll1: List[Int], coll2: List[Int]) : List[Int] = {
+    val g = (i: Int) => (j: Int) => i * N + j
+    val f = (i: Int) => coll2.map(g(i))
+    coll1.flatMap(f)
+  }
+
+  def nestedLoop3(coll1: List[Int], coll2: List[Int]) : List[Int] = {
+    val g = (i: Int) => (j: Int) => i * N + j
+    val f = (i: Int) => coll2.map(g(i))
+    coll1.map(f).flatten
+  }
+}
+
+class NestedLoop1Bench extends BaseBenchmark {
+  val n = new NestedLoop1()
+  import n._
+
+  performance of "nestedLoop1" in {
+    nestedLoop1(coll1Init, coll2Init)
+  }
+}

--- a/src/test/scala/ilc/examples/handwritten/NestedLoop1.scala
+++ b/src/test/scala/ilc/examples/handwritten/NestedLoop1.scala
@@ -89,15 +89,11 @@ class NestedLoop1 extends Serializable {
   }
 }
 
-class NestedLoop1Bench extends BaseBenchmark {
-  val n = new NestedLoop1()
-  import n._
-  val (res1, res1Cache) = nestedLoop3Memo(coll1Init, coll2Init)
-
+class MyBenchmarkingSetup extends BaseBenchmark {
   override def reporters = Seq(LoggingReporter())
   override def buildExecutor = separateExecutor
   //To make tests fast and have lots of memory
-  def myConfig =
+  def myBenchConfig =
     Context(
       //reports.regression.significance -> 0.01, //Confidence level = 99 %
       exec.jvmflags -> s"-Xmx${memorySizeMB}m -Xms${memorySizeMB}m -XX:CompileThreshold=100",
@@ -108,34 +104,41 @@ class NestedLoop1Bench extends BaseBenchmark {
       exec.independentSamples -> 1,
       exec.reinstantiation.fullGC -> false,
       verbose -> false)
+}
+
+
+class NestedLoop1Bench extends MyBenchmarkingSetup {
+  val n = new NestedLoop1()
+  import n._
+  val (res1, res1Cache) = nestedLoop3Memo(coll1Init, coll2Init)
 
   performance of "nestedLoop1" in {
-    using(Gen.unit("dummy")) config myConfig in { _ =>
+    using(Gen.unit("dummy")) config myBenchConfig in { _ =>
       nestedLoop1(coll1Init, coll2Init)
     }
   }
 
   performance of "nestedLoop3" in {
-    using(Gen.unit("dummy")) config myConfig in { _ =>
+    using(Gen.unit("dummy")) config myBenchConfig in { _ =>
       nestedLoop3(coll1Init, coll2Init)
     }
   }
 
   performance of "nestedLoop3Memo" in {
-    using(Gen.unit("dummy")) config myConfig in { _ =>
+    using(Gen.unit("dummy")) config myBenchConfig in { _ =>
       nestedLoop3Memo(coll1Init, coll2Init)
     }
   }
 
   performance of "nestedLoop3Incr" in {
-    using(Gen.unit("dummy")) config myConfig in { _ =>
+    using(Gen.unit("dummy")) config myBenchConfig in { _ =>
       nestedLoop3Incr(coll1Init, coll2Init)(res1, res1Cache)(0, N, true)
     }
   }
 
   //Cheat a lot, to get closer to the performance we'd hope with proper data structures.
   performance of "nestedLoop3IncrSimulated" in {
-    using(Gen.unit("dummy")) config myConfig in { _ =>
+    using(Gen.unit("dummy")) config myBenchConfig in { _ =>
       nestedLoop3Incr(coll1Init, coll2Init)(res1, res1Cache)(0, N, false)
     }
   }

--- a/src/test/scala/ilc/util/Util.scala
+++ b/src/test/scala/ilc/util/Util.scala
@@ -1,0 +1,6 @@
+package ilc.util
+
+object Util {
+  def assertType[T](t: T) {}
+  def assertTypeAndRet[T](t: T) = t
+}


### PR DESCRIPTION
This code relates to Blaisorblade/ilc-ldiff#14. Not to merge yet.
Currently, memoization works well (apart from the horrible memory consumption) and saves lots of time; however, the implementation of unordered collection (bags) I'm using (which I quickly hacked together, on top of HashMaps) is very inefficient, both in theory and in practice, with a slowdown of a factor of 100 (as shown below).

I've reused *some* code from our benchmark, but lots of code there wasn't conveniently usable so I reimplemented some correct version very quickly.

```
[info] ::Benchmark nestedLoop1::
[info] cores: 8
[info] hostname: tatooine.Informatik.Uni-Tuebingen.De
[info] jvm-name: Java HotSpot(TM) 64-Bit Server VM
[info] jvm-vendor: Oracle Corporation
[info] jvm-version: 24.51-b03
[info] os-arch: x86_64
[info] os-name: Mac OS X
[info] Parameters(dummy -> ()): 10.169
[info]
[info] ::Benchmark nestedLoop3::
[info] cores: 8
[info] hostname: tatooine.Informatik.Uni-Tuebingen.De
[info] jvm-name: Java HotSpot(TM) 64-Bit Server VM
[info] jvm-vendor: Oracle Corporation
[info] jvm-version: 24.51-b03
[info] os-arch: x86_64
[info] os-name: Mac OS X
[info] Parameters(dummy -> ()): 18.16
[info]
[info] ::Benchmark nestedLoop3Memo::
[info] cores: 8
[info] hostname: tatooine.Informatik.Uni-Tuebingen.De
[info] jvm-name: Java HotSpot(TM) 64-Bit Server VM
[info] jvm-vendor: Oracle Corporation
[info] jvm-version: 24.51-b03
[info] os-arch: x86_64
[info] os-name: Mac OS X
[info] Parameters(dummy -> ()): 13.701
[info]
[info] ::Benchmark nestedLoop3Incr::
[info] cores: 8
[info] hostname: tatooine.Informatik.Uni-Tuebingen.De
[info] jvm-name: Java HotSpot(TM) 64-Bit Server VM
[info] jvm-vendor: Oracle Corporation
[info] jvm-version: 24.51-b03
[info] os-arch: x86_64
[info] os-name: Mac OS X
[info] Parameters(dummy -> ()): 11.176
[info]
[info] ::Benchmark nestedLoop3IncrSimulated::
[info] cores: 8
[info] hostname: tatooine.Informatik.Uni-Tuebingen.De
[info] jvm-name: Java HotSpot(TM) 64-Bit Server VM
[info] jvm-vendor: Oracle Corporation
[info] jvm-version: 24.51-b03
[info] os-arch: x86_64
[info] os-name: Mac OS X
[info] Parameters(dummy -> ()): 0.132
[info]
[info] ::Benchmark nestedLoopBags1::
[info] cores: 8
[info] hostname: tatooine.Informatik.Uni-Tuebingen.De
[info] jvm-name: Java HotSpot(TM) 64-Bit Server VM
[info] jvm-vendor: Oracle Corporation
[info] jvm-version: 24.51-b03
[info] os-arch: x86_64
[info] os-name: Mac OS X
[info] Parameters(dummy -> ()): 1143.986
[info]
[info] ::Benchmark nestedLoopBags3::
[info] cores: 8
[info] hostname: tatooine.Informatik.Uni-Tuebingen.De
[info] jvm-name: Java HotSpot(TM) 64-Bit Server VM
[info] jvm-vendor: Oracle Corporation
[info] jvm-version: 24.51-b03
[info] os-arch: x86_64
[info] os-name: Mac OS X
[info] Parameters(dummy -> ()): 995.711
[info]
[info] ::Benchmark nestedLoopBags3Memo::
[info] cores: 8
[info] hostname: tatooine.Informatik.Uni-Tuebingen.De
[info] jvm-name: Java HotSpot(TM) 64-Bit Server VM
[info] jvm-vendor: Oracle Corporation
[info] jvm-version: 24.51-b03
[info] os-arch: x86_64
[info] os-name: Mac OS X
[info] Parameters(dummy -> ()): 1065.73
[info]
[info] ::Benchmark nestedLoopBags3Incr::
[info] cores: 8
[info] hostname: tatooine.Informatik.Uni-Tuebingen.De
[info] jvm-name: Java HotSpot(TM) 64-Bit Server VM
[info] jvm-vendor: Oracle Corporation
[info] jvm-version: 24.51-b03
[info] os-arch: x86_64
[info] os-name: Mac OS X
[info] Parameters(dummy -> ()): 15.498
```