### PR TITLE
Tune homegrown bags

### DIFF
--- a/src/test/scala/ilc/examples/handwritten/NestedLoop1.scala
+++ b/src/test/scala/ilc/examples/handwritten/NestedLoop1.scala
@@ -14,10 +14,10 @@ import org.scalameter.api._
 case class Bag[A](contents: immutable.Map[A, Int] = immutable.HashMap()) {
   import feature.bags.{Library => BagLib}
 
-  private def mapCommon[B](f: A => B) = {
-     for {
-      (el, count) <- contents.toSeq //.toSeq is just to change the result type. Alternatively, just use breakOut.
-    } yield (f(el), count)
+  private def mapCommon[B](f: A => B): Seq[(B, Int)] = {
+    contents.map {
+      case (el, count) => (f(el), count)
+    } (collection.breakOut)
   }
 
   /**

--- a/src/test/scala/ilc/examples/handwritten/NestedLoop1.scala
+++ b/src/test/scala/ilc/examples/handwritten/NestedLoop1.scala
@@ -13,11 +13,12 @@ import org.scalameter.api._
  */
 case class Bag[A](contents: immutable.Map[A, Int] = immutable.HashMap()) {
   import feature.bags.{Library => BagLib}
+  import collection.generic.CanBuildFrom
 
-  private def mapCommon[B](f: A => B): Seq[(B, Int)] = {
+  private def mapCommon[B, To](f: A => B)(implicit cbf: CanBuildFrom[Map[A, Int], (B, Int), To]): To = {
     contents.map {
       case (el, count) => (f(el), count)
-    } (collection.breakOut)
+    } (cbf)
   }
 
   /**
@@ -25,7 +26,7 @@ case class Bag[A](contents: immutable.Map[A, Int] = immutable.HashMap()) {
    * Precondition: f is injective. Otherwise, resort to map.
    */
   def mapInjective[B](f: A => B): Bag[B] = {
-    new Bag(mapCommon(f).toMap)
+    new Bag(mapCommon(f))
   }
 
   /**
@@ -34,7 +35,7 @@ case class Bag[A](contents: immutable.Map[A, Int] = immutable.HashMap()) {
    * Untested.
    */
   def map[B](f: A => B): Bag[B] = {
-    val internalMap = mapCommon(f).
+    val internalMap = (mapCommon(f)(collection.breakOut): Seq[(B, Int)]).
       //F might not be injective
       map { case (el, count) => immutable.HashMap((el, count)) }.
       fold(BagLib.bagEmpty[B])(BagLib.bagUnionInt _)

--- a/src/test/scala/ilc/examples/handwritten/NestedLoop1.scala
+++ b/src/test/scala/ilc/examples/handwritten/NestedLoop1.scala
@@ -35,6 +35,13 @@ case class Bag[A](contents: immutable.Map[A, Int] = immutable.HashMap()) {
    * Untested.
    */
   def map[B](f: A => B): Bag[B] = {
+    /*
+    import mutable.MapBuilder
+    val b = new MapBuilder(immutable.HashMap())
+    for {
+      (el, count) <- contents
+    }
+    */
     val internalMap = (mapCommon(f)(collection.breakOut): Seq[(B, Int)]).
       //F might not be injective
       map { case (el, count) => immutable.HashMap((el, count)) }.


### PR DESCRIPTION
This is potentially useful because library bags need some refinement to get good performance.

However, homegrown bags stay commented out, for now.