### PR TITLE
Implement Hindley-Milner type inference

### DIFF
--- a/src/main/scala/ilc/feature/inference/Inference.scala
+++ b/src/main/scala/ilc/feature/inference/Inference.scala
@@ -384,14 +384,6 @@ trait MiniMLInference extends LetInference with MiniMLSyntax with MiniMLTypes {
     freeVars.foldRight(t)(Forall(_, _))
   }
 
-  /*
-  def generalizeBodyWithCtx(t: Type, ctx: InferenceContext, body: Term): Term = {
-    assert(isMono(t))
-    val freeVars = (freeTypeVars(t) -- ctx.values.flatMap(freeTypeVars)).toList.sorted
-    freeVars.foldRight(body)(TLambda(_, _))
-  }
-  */
-
   /**
    * Potentially wrap body to have the more general type given by targetType.
    */

--- a/src/main/scala/ilc/feature/inference/Inference.scala
+++ b/src/main/scala/ilc/feature/inference/Inference.scala
@@ -320,3 +320,24 @@ trait LetRecInference extends Inference with LetRecUntypedSyntax with functions.
     case _ => super.typedTermToTerm(tt)
   }
 }
+
+trait MiniMLTypes extends TVars {
+  //HOAS for type binders? No, we use productIterator for traversals, so not.
+//  case class Forall(tBody: Type => Type) extends Type {
+//    override def traverse(f: Type => Type): Type = {
+//      val tVar = freshTypeVariable()
+//      Forall(x => substituteInType(Map(tVar -> x))(f(tBody(tVar))))
+//    }
+//  }
+  case class Forall(tVar: TypeVariable, tBody: Type) extends Type {
+    override def traverse(f: Type => Type): Type =
+      Forall(tVar, f(tBody))
+  }
+}
+
+trait MiniMLSyntax extends base.Syntax with MiniMLTypes {
+  case class TLambda(tVar: TypeVariable, body: Term) extends Term
+  {
+    override lazy val getType = Forall(tVar, body.getType)
+  }
+}

--- a/src/main/scala/ilc/feature/inference/Inference.scala
+++ b/src/main/scala/ilc/feature/inference/Inference.scala
@@ -144,6 +144,18 @@ trait Inference
     case _ => sys error s"Cannot infer type for $term"
   }
 
+  def freeTypeVars(t: Type): Set[TypeVariable] = t match {
+    case tv: TypeVariable => Set(tv)
+    case _ =>
+      val freeVars = t.productIterator.flatMap { member =>
+        member match {
+          case typ: Type => freeTypeVars(typ)
+          case _         => Set.empty[TypeVariable]
+        }
+      }
+      freeVars.toSet
+  }
+
   def occurs(variable: TypeVariable, value: Type): Boolean = value match {
     case tv: TypeVariable => tv == variable
     case _ =>

--- a/src/main/scala/ilc/feature/inference/Inference.scala
+++ b/src/main/scala/ilc/feature/inference/Inference.scala
@@ -148,10 +148,13 @@ extends base.Syntax
 
   def occurs(variable: TypeVariable, value: Type): Boolean = value match {
     case tv: TypeVariable => tv == variable
-    case _ => value.productIterator.exists(member =>
-      if (member.isInstanceOf[Type])
-        occurs(variable, member.asInstanceOf[Type])
-      else false)
+    case _ =>
+      value.productIterator.exists { member =>
+        member match {
+          case typ: Type => occurs(variable, member.asInstanceOf[Type])
+          case _         => false
+        }
+      }
   }
 
   def quickTraverse(f: Type => Type)(t: Type): Type =

--- a/src/main/scala/ilc/feature/inference/Inference.scala
+++ b/src/main/scala/ilc/feature/inference/Inference.scala
@@ -107,7 +107,7 @@ trait Inference
   //but we just need to use the Set[Constraint] output with their monoid to fix this).
   def mergeInferenceContexts(ctx1: InferenceContext, ctx2: InferenceContext): (InferenceContext, Set[Constraint]) = {
     val commonNames = ctx1.keySet intersect ctx2.keySet
-    val cSet = commonNames map (name => Constraint(ctx1(name), (ctx2)(name)))
+    val cSet = commonNames map (name => Constraint(ctx1(name), ctx2(name)))
     val ctx = (ctx1 -- commonNames) ++ (ctx2 -- commonNames) ++
       //we could pick ctx2, but we output equality constraints such that the
       //two choices are equivalent.

--- a/src/main/scala/ilc/feature/inference/Inference.scala
+++ b/src/main/scala/ilc/feature/inference/Inference.scala
@@ -32,7 +32,7 @@ trait Inference
   val typeVariableCounter: AtomicInteger = new AtomicInteger()
   def _freshTypeVariable(uterm: Option[UntypedTerm]): TypeVariable = TypeVariable(typeVariableCounter.incrementAndGet(), uterm)
   def freshTypeVariable(uterm: UntypedTerm): TypeVariable = _freshTypeVariable(Some(uterm))
-  def freshTypeVariable: TypeVariable = _freshTypeVariable(None)
+  def freshTypeVariable(): TypeVariable = _freshTypeVariable(None)
 
   case class Constraint(actual: Type, expected: Type, ctx: String = "", parent: Option[Constraint] = None) {
     def pretty(showTerm: Boolean = true): String =

--- a/src/main/scala/ilc/feature/inference/Inference.scala
+++ b/src/main/scala/ilc/feature/inference/Inference.scala
@@ -103,17 +103,11 @@ trait Inference
   //implicit def GenericTypedTerm = Generic[TypedTerm]
 
   def collectConstraints(term: UntypedTerm): (TypedTerm, Set[Constraint]) = {
-    //XXX
-    val (tt, cs, ctx) = doCollectConstraints(term)
-    (tt, cs)
-  }
-
-  private final def doCollectConstraints(term: UntypedTerm): (TypedTerm, Set[Constraint], InferenceContext) = {
     val freeTermVars = (freeVars(term) -- initContext.keys).toSeq
     val freshTypingCtx = InferenceContext(freeTermVars map (n => (n, freshTypeVariable(UVar(n)))): _*)
     val ctx = initContext ++ freshTypingCtx
     val (tt, constraints) = doCollectConstraintsFromCtx(term, ctx)
-    (tt, constraints, ctx)
+    (tt, constraints) //And ctx ?
   }
 
   /**
@@ -393,7 +387,6 @@ trait MiniMLInference extends LetInference with MiniMLSyntax with MiniMLTypes {
   }
 
   override def specialize(t: Type) = {
-    //XXX untested, and quickTraverse is not really well-documented.
     quickTraverse {
       case Forall(tVar, tBody) =>
         //Quadratic worst-case complexity. We should remove and accumulate type variables and use parallel substitution.

--- a/src/main/scala/ilc/feature/inference/UntypedSyntax.scala
+++ b/src/main/scala/ilc/feature/inference/UntypedSyntax.scala
@@ -13,16 +13,39 @@ trait UntypedSyntax {
   case class UMonomorphicConstant(term: Term) extends UntypedTerm
   case class UPolymorphicConstant(term: PolymorphicConstant) extends UntypedTerm
   case class TypeAscription(term: UntypedTerm, typ: Type) extends UntypedTerm
+
+  def freeVars(t: UntypedTerm): Set[Name] = t match {
+    case UVar(n)                 => Set(n)
+    case UAbs(n, _, body)        => freeVars(body) - n
+    case UApp(f, arg)            => freeVars(f) ++ freeVars(arg)
+    case TypeAscription(t, _)    => freeVars(t)
+    case UMonomorphicConstant(_) => Set.empty
+    case UPolymorphicConstant(_) => Set.empty
+  }
 }
 
 trait LetUntypedSyntax extends UntypedSyntax {
   this: base.Syntax with functions.Syntax =>
 
   case class ULet(variable: Name, exp: UntypedTerm, body: UntypedTerm) extends UntypedTerm
+  override def freeVars(t: UntypedTerm) = t match {
+    case ULet(v, exp, body) =>
+      // Parens are important here: if there's shadowing, v can be free on the
+      // LHS.
+      freeVars(exp) ++ (freeVars(body) - v)
+    case _ =>
+      super.freeVars(t)
+  }
 }
 
 trait LetRecUntypedSyntax extends UntypedSyntax {
   this: base.Syntax with functions.Syntax =>
 
   case class ULetRec(pairs: List[(Name, UntypedTerm)], bodyName: Name, body: UntypedTerm) extends UntypedTerm
+  override def freeVars(t: UntypedTerm) = t match {
+    case ULetRec(pairs, _, body) =>
+      freeVars(body) ++ (pairs flatMap (x => freeVars(x._2))) -- (pairs map (_._1))
+    case _ =>
+      super.freeVars(t)
+  }
 }

--- a/src/main/scala/ilc/feature/inference/UntypedSyntax.scala
+++ b/src/main/scala/ilc/feature/inference/UntypedSyntax.scala
@@ -3,7 +3,7 @@ package feature
 package inference
 
 trait UntypedSyntax {
-  this: base.Syntax with functions.Syntax =>
+  this: base.Syntax =>
 
   trait UntypedTerm
 

--- a/src/test/scala/ilc/feature/inference/InferenceSuite.scala
+++ b/src/test/scala/ilc/feature/inference/InferenceSuite.scala
@@ -19,6 +19,23 @@ with integers.ImplicitSyntaxSugar
 {
   val (t0, t1, t2, t3, t4, t5, t6, t7, t8, t9) = (TypeVariable(0), TypeVariable(1), TypeVariable(2), TypeVariable(3), TypeVariable(4), TypeVariable(5), TypeVariable(6), TypeVariable(7), TypeVariable(8), TypeVariable(9))
 
+  def occursEquivFreeVars(tv: TypeVariable, t: Type) = {
+    occurs(tv, t) === freeTypeVars(t).contains(tv)
+  }
+
+  "Type variable computation" should "work" in {
+    freeTypeVars(t0 =>: t1 =>: t2) === (Set(t0, t1, t2))
+    freeTypeVars((t0 =>: t1) =>: t2) === (Set(t0, t1, t2))
+    freeTypeVars(BagType(t0 =>: t1) =>: t2) === (Set(t0, t1, t2))
+  }
+
+  "Occurs check" should "be equivalent to computing and checking free variables" in {
+    occursEquivFreeVars(t0, t0 =>: t0)
+    occursEquivFreeVars(t0, t0 =>: t1)
+    occursEquivFreeVars(t0, BagType(t0) =>: t1)
+    occursEquivFreeVars(t0, t1 =>: BagType(t2))
+  }
+
   "Unification" should "produce no substitutions for equal constraints" in {
     val s: Set[Constraint] = Set(Constraint(TypeVariable(1), TypeVariable(1)))
     assert(unification(s) === Map())

--- a/src/test/scala/ilc/feature/inference/InferenceSuite.scala
+++ b/src/test/scala/ilc/feature/inference/InferenceSuite.scala
@@ -92,7 +92,7 @@ class InferenceSuite extends InferenceSuiteHelper {
 
   it should "work correctly on open LetRec terms" in {
     val vU = ULetRec(List(("fac", 'x ->: 'fac('fac('x)))), "letRecBodyName",
-        asUntyped(Pair)('fac(1: Term), 'freeVar))
+        asUntyped(Pair)('fac(1), 'freeVar))
     typecheck(vU)
   }
 
@@ -104,14 +104,14 @@ class InferenceSuite extends InferenceSuiteHelper {
   }
 
   it should "work on LetRec" in {
-    val vU = ULetRec(List(("fac", 'x ->: 'fac('fac('x)))), "letRecBodyName", 'fac(1: Term))
+    val vU = ULetRec(List(("fac", 'x ->: 'fac('fac('x)))), "letRecBodyName", 'fac(1))
     val typed = typecheck(vU)
     assert(dropSourceInfo(typed.getType) === IntType)
   }
 
   it should "work on LetRec2" in {
     val vU = ULetRec(List(("fac", 'x ->: 'fac('fac('x))),
-        ("facc", 'fac)), "letRecBodyName", asUntyped(Pair)('fac(1: Term), 'facc))
+        ("facc", 'fac)), "letRecBodyName", asUntyped(Pair)('fac(1), 'facc))
     val typed = typecheck(vU)
     println(typecheck(vU))
     assert(dropSourceInfo(typed.getType) === ProductType(IntType, IntType =>: IntType))
@@ -126,7 +126,7 @@ class InferenceSuite extends InferenceSuiteHelper {
   it should "not relate identifiers bounds in different Lets" in {
     val vU =
       letS(
-      'h := 'x ->: letS('f := 'x ->: 'x)('f(1: Term)),
+      'h := 'x ->: letS('f := 'x ->: 'x)('f(1)),
       'i := 'x ->: letS('f := 'x ->: 'x)('f(EmptyBag)))('h)
     typecheck(vU)
   }
@@ -134,7 +134,7 @@ class InferenceSuite extends InferenceSuiteHelper {
   it should "not relate identifiers bounds in different LetRec" in {
     val vU =
       letS(
-      'g := 'x ->: ULetRec(List(("f", 'x ->: 'f('f('x)))), "", 'f(1: Term)),
+      'g := 'x ->: ULetRec(List(("f", 'x ->: 'f('f('x)))), "", 'f(1)),
       'h := 'x ->: ULetRec(List(("f", 'x ->: 'f('f('x)))), "", 'f(EmptyBag)))('g)
     typecheck(vU)
   }
@@ -143,7 +143,7 @@ class InferenceSuite extends InferenceSuiteHelper {
     val vU =
       letS(
         'f := 'x ->: 'x
-      )(asUntyped(Pair)('f(1: Term), 'f(EmptyBag)))
+      )(asUntyped(Pair)('f(1), 'f(EmptyBag)))
     intercept[Throwable] {
       typecheck(vU)
     }
@@ -152,7 +152,7 @@ class InferenceSuite extends InferenceSuiteHelper {
     val vU =
       letS(
         'f := 'x ->: 'x
-      )('bag ->: asUntyped(Pair)('f(1: Term), 'f('bag)))
+      )('bag ->: asUntyped(Pair)('f(1), 'f('bag)))
     typecheck(vU)
     //XXX check result is as expected
   }
@@ -175,7 +175,7 @@ class HMInferenceSuite extends InferenceSuiteHelper with MiniMLInference {
     val vU =
       letS(
         'f := 'x ->: 'x
-      )(asUntyped(Pair)('f(1: Term), 'f(EmptyBag)))
+      )(asUntyped(Pair)('f(1), 'f(EmptyBag)))
     typecheck(vU)
   }
 
@@ -183,7 +183,7 @@ class HMInferenceSuite extends InferenceSuiteHelper with MiniMLInference {
     val vU =
       letS(
         'f := 'x ->: 'x
-      )('bag ->: asUntyped(Pair)('f(1: Term), 'f('bag)))
+      )('bag ->: asUntyped(Pair)('f(1), 'f('bag)))
     typecheck(vU)
   }
 

--- a/src/test/scala/ilc/feature/inference/InferenceSuite.scala
+++ b/src/test/scala/ilc/feature/inference/InferenceSuite.scala
@@ -3,7 +3,7 @@ package ilc.feature.inference
 import org.scalatest._
 import ilc.feature._
 
-class InferenceSuite
+trait InferenceSuiteHelper
 extends FlatSpec
    with Inference
    with SyntaxSugar
@@ -12,17 +12,19 @@ extends FlatSpec
    with LetRecInference
    with base.Pretty
 
-// Stuff for testing old inference
-with InferenceTestHelper
-with bags.Syntax
-with integers.ImplicitSyntaxSugar
+   with InferenceTestHelper
+   with bags.Syntax
+   with products.Syntax
+   with integers.ImplicitSyntaxSugar
 {
   val (t0, t1, t2, t3, t4, t5, t6, t7, t8, t9) = (TypeVariable(0), TypeVariable(1), TypeVariable(2), TypeVariable(3), TypeVariable(4), TypeVariable(5), TypeVariable(6), TypeVariable(7), TypeVariable(8), TypeVariable(9))
 
   def occursEquivFreeVars(tv: TypeVariable, t: Type) = {
     occurs(tv, t) === freeTypeVars(t).contains(tv)
   }
+}
 
+class InferenceSuite extends InferenceSuiteHelper {
   "Type variable computation" should "work" in {
     freeTypeVars(t0 =>: t1 =>: t2) === (Set(t0, t1, t2))
     freeTypeVars((t0 =>: t1) =>: t2) === (Set(t0, t1, t2))
@@ -74,7 +76,7 @@ with integers.ImplicitSyntaxSugar
     }
   }
 
-  "Type inference" should "infer α -> α for (id id)" in {
+  "Non-HM type inference" should "infer α -> α for (id id)" in {
     val id: UntypedTerm = UAbs("x", None, UVar("x"))
     val (typedTerm, constraints) = collectConstraints(UApp(id, id))
     val solved = unification(constraints)


### PR DESCRIPTION
Warning: not extensively tested.

Main highlights:
- the context is now an input, not an output; however, for open terms where we don't know the context, we simply generate a context using fresh type variables for the free term variables.
- simplify constraints generation: since the context is now an input, we no more need to merge constraints, simplifying some code.